### PR TITLE
Translate remaining log and map messages

### DIFF
--- a/Controls/DefaultSettings.cs
+++ b/Controls/DefaultSettings.cs
@@ -83,7 +83,7 @@ namespace MissionPlanner.Controls
                 ThemeManager.ApplyThemeTo(paramCompareForm);
                 if (paramCompareForm.ShowDialog() == DialogResult.OK)
                 {
-                    CustomMessageBox.Show("Loaded parameters!", "Loaded");
+                    CustomMessageBox.Show("Параметры загружены!", "Загружено");
                 }
 
                 if (OnChange != null)
@@ -96,7 +96,7 @@ namespace MissionPlanner.Controls
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to load file.\n" + ex);
+                CustomMessageBox.Show("Не удалось загрузить файл.\n" + ex);
             }
         }
 

--- a/Controls/ElevationProfile.cs
+++ b/Controls/ElevationProfile.cs
@@ -231,7 +231,7 @@ namespace MissionPlanner.Controls
 
             if (list.Count < 2 || coords.Length > (2048 - 256))
             {
-                CustomMessageBox.Show("Too many/few WP's or to Big a Distance " + (distance / 1000) + "km", Strings.ERROR);
+                CustomMessageBox.Show("Слишком много/мало точек маршрута или слишком большое расстояние " + (distance / 1000) + "км", Strings.ERROR);
                 return answer;
             }
 
@@ -269,7 +269,7 @@ namespace MissionPlanner.Controls
             }
             catch
             {
-                CustomMessageBox.Show("Error getting GE data", Strings.ERROR);
+                CustomMessageBox.Show("Ошибка получения данных GE", Strings.ERROR);
             }
 
             return answer;

--- a/Controls/GimbalControlSettingsForm.cs
+++ b/Controls/GimbalControlSettingsForm.cs
@@ -262,15 +262,15 @@ namespace MissionPlanner.Controls
             if (clashList.Count > 0)
             {
                 var clashMessage = new StringBuilder();
-                clashMessage.AppendLine("This binding is already used by the following:");
+                clashMessage.AppendLine("Эта привязка уже используется следующими:");
                 clashMessage.AppendLine();
                 foreach (var clash in clashList)
                 {
                     clashMessage.AppendLine($"- {clash.LabelText}");
                 }
                 clashMessage.AppendLine();
-                clashMessage.AppendLine("Are you sure you want to use this binding?");
-                return CustomMessageBox.Show(clashMessage.ToString(), "Key Binding Clash", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+                clashMessage.AppendLine("Вы уверены, что хотите использовать эту привязку?");
+                return CustomMessageBox.Show(clashMessage.ToString(), "Конфликт назначений клавиш", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
             }
 
             return (int)DialogResult.Yes;

--- a/Controls/MavlinkComboBox.cs
+++ b/Controls/MavlinkComboBox.cs
@@ -179,7 +179,7 @@ namespace MissionPlanner.Controls
 
                     if (!MainV2.comPort.setParam((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, ParamName, (float)(int)((MavlinkComboBox)sender).SelectedValue))
                     {
-                        CustomMessageBox.Show("Set " + ParamName + " Failed!", Strings.ERROR);
+                        CustomMessageBox.Show("Не удалось установить " + ParamName + "!", Strings.ERROR);
                     }
 
                     if (paramname2 != "")
@@ -188,13 +188,13 @@ namespace MissionPlanner.Controls
                             !MainV2.comPort.setParam((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, paramname2,
                                 (float)(int)((MavlinkComboBox)sender).SelectedValue > 0 ? 1 : 0))
                         {
-                            CustomMessageBox.Show("Set " + paramname2 + " Failed!", Strings.ERROR);
+                            CustomMessageBox.Show("Не удалось установить " + paramname2 + "!", Strings.ERROR);
                         }
                     }
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Set " + ParamName + " Failed!", Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось установить " + ParamName + "!", Strings.ERROR);
                 }
             }
         }

--- a/Controls/RAW_Sensor.cs
+++ b/Controls/RAW_Sensor.cs
@@ -260,7 +260,7 @@ namespace MissionPlanner.Controls
             }
             catch
             {
-                CustomMessageBox.Show("Comport open failed");
+                CustomMessageBox.Show("Не удалось открыть COM-порт");
                 return;
             }
             timer1.Start();

--- a/Controls/SerialOutputCoT.cs
+++ b/Controls/SerialOutputCoT.cs
@@ -125,7 +125,7 @@ namespace MissionPlanner.Controls
             }
             catch
             {
-                CustomMessageBox.Show("Error Connecting\nif using com0com please rename the ports to COM??");
+                CustomMessageBox.Show("Ошибка подключения\nесли используется com0com, переименуйте порты в COM??");
                 return;
             }
 

--- a/Controls/SerialOutputMD.cs
+++ b/Controls/SerialOutputMD.cs
@@ -60,7 +60,7 @@ namespace MissionPlanner.Controls
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Error Connecting\nif using com0com please rename the ports to COM??");
+                    CustomMessageBox.Show("Ошибка подключения\nесли используется com0com, переименуйте порты в COM??");
                     return;
                 }
 

--- a/Controls/SerialOutputNMEA.cs
+++ b/Controls/SerialOutputNMEA.cs
@@ -106,7 +106,7 @@ namespace MissionPlanner.Controls
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Error Connecting\nif using com0com please rename the ports to COM??");
+                    CustomMessageBox.Show("Ошибка подключения\nесли используется com0com, переименуйте порты в COM??");
                     return;
                 }
 

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapControl.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/GMapControl.cs
@@ -2597,11 +2597,11 @@ namespace GMap.NET.WindowsForms
                     bool ok = GMaps.Instance.ExportToGMDB(dlg.FileName);
                     if (ok)
                     {
-                        MessageBox.Show("Complete!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        MessageBox.Show("Завершено!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
                     else
                     {
-                        MessageBox.Show("Failed!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        MessageBox.Show("Ошибка!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
 
                     return ok;
@@ -2636,12 +2636,12 @@ namespace GMap.NET.WindowsForms
                     bool ok = GMaps.Instance.ImportFromGMDB(dlg.FileName);
                     if (ok)
                     {
-                        MessageBox.Show("Complete!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        MessageBox.Show("Завершено!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Information);
                         ReloadMap();
                     }
                     else
                     {
-                        MessageBox.Show("Failed!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        MessageBox.Show("Ошибка!", "GMap.NET", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
 
                     return ok;

--- a/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
+++ b/ExtLibs/GMap.NET.WindowsForms/GMap.NET.WindowsForms/TilePrefetcher.cs
@@ -161,11 +161,11 @@ namespace GMap.NET
          {
             if(!e.Cancelled)
             {
-               MessageBox.Show(this, "Prefetch Complete! => " + ((int)e.Result).ToString() + " of " + all);
+               MessageBox.Show(this, "Предзагрузка завершена! => " + ((int)e.Result).ToString() + " из " + all);
             }
             else
             {
-               MessageBox.Show(this, "Prefetch Canceled! => " + ((int)e.Result).ToString() + " of " + all);
+               MessageBox.Show(this, "Предзагрузка отменена! => " + ((int)e.Result).ToString() + " из " + all);
             }
          }
 
@@ -355,7 +355,7 @@ namespace GMap.NET
 
       private void ConfirmUserAbort()
       {
-          if (MessageBox.Show("Are you sure you want to abort the pre-fetch process?", "Confirm Abort", MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button1) == System.Windows.Forms.DialogResult.Yes)
+          if (MessageBox.Show("Вы уверены, что хотите прервать процесс предварительной загрузки?", "Подтвердите прерывание", MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button1) == System.Windows.Forms.DialogResult.Yes)
           {
               UserAborted = true;
               this.Close();

--- a/ExtLibs/Strings/Strings.Designer.cs
+++ b/ExtLibs/Strings/Strings.Designer.cs
@@ -70,7 +70,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Are you sure you want to upload .
+        ///   Looks up a localized string similar to Вы уверены, что хотите загрузить .
         /// </summary>
         public static string AreYouSureYouWantToUpload {
             get {
@@ -223,7 +223,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bad OptFlow Health.
+        ///   Looks up a localized string similar to Неисправность датчика оптического потока.
         /// </summary>
         public static string BadOptFlowHealth {
             get {
@@ -232,7 +232,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Bad or No Terrain Data.
+        ///   Looks up a localized string similar to Некорректные или отсутствующие данные рельефа.
         /// </summary>
         public static string BadorNoTerrainData {
             get {
@@ -259,7 +259,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to These are beta firmware, use at your own risk!!!.
+        ///   Looks up a localized string similar to Это бета-прошивка, используйте на свой риск!!!.
         /// </summary>
         public static string BetaWarning {
             get {
@@ -277,7 +277,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can not connect to com port and detect board type.
+        ///   Looks up a localized string similar to Не удалось подключиться к COM-порту и определить тип платы.
         /// </summary>
         public static string CanNotConnectToComPortAnd {
             get {
@@ -413,7 +413,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Continue.
+        ///   Looks up a localized string similar to Продолжить.
         /// </summary>
         public static string Continue {
             get {
@@ -677,7 +677,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error uploading firmware.
+        ///   Looks up a localized string similar to Ошибка загрузки прошивки.
         /// </summary>
         public static string ErrorUploadingFirmware {
             get {
@@ -803,7 +803,7 @@ namespace MissionPlanner {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Geofence Breach.
+        ///   Looks up a localized string similar to Нарушение геозоны.
         /// </summary>
         public static string GeofenceBreach {
             get {

--- a/ExtLibs/Strings/Strings.resx
+++ b/ExtLibs/Strings/Strings.resx
@@ -289,54 +289,54 @@ DON'T DO THIS IF YOU ARE IN THE AIR
   </data>
   <data name="Pleaseup" xml:space="preserve">
     <value>
-Please upgrade</value>
+Пожалуйста, обновите</value>
   </data>
   <data name="Stillmoving" xml:space="preserve">
-    <value>Your model is still moving are you sure you want to disconnect?</value>
+    <value>Модель еще движется. Вы уверены, что хотите отключиться?</value>
   </data>
   <data name="Timeout" xml:space="preserve">
-    <value>Timeout waiting for autoscan/no mavlink device connected</value>
+    <value>Истекло время ожидания автосканирования/нет mavlink соединения</value>
   </data>
   <data name="ConnectFailed" xml:space="preserve">
-    <value>Connect Failed</value>
+    <value>Не удалось подключиться</value>
   </data>
   <data name="ConnectingMavlink" xml:space="preserve">
-    <value>Connecting Mavlink</value>
+    <value>Подключение Mavlink</value>
   </data>
   <data name="Done" xml:space="preserve">
-    <value>Done</value>
+    <value>Готово</value>
   </data>
   <data name="GettingParams" xml:space="preserve">
-    <value>Getting Params</value>
+    <value>Получение параметров</value>
   </data>
   <data name="GettingParamsD" xml:space="preserve">
-    <value>Getting Params...</value>
+    <value>Получение параметров...</value>
   </data>
   <data name="Gotparam" xml:space="preserve">
-    <value>Got param </value>
+    <value>Получен параметр </value>
   </data>
   <data name="MavlinkConnecting" xml:space="preserve">
-    <value>Mavlink Connecting...</value>
+    <value>Подключение Mavlink...</value>
   </data>
   <data name="Only1Hb" xml:space="preserve">
-    <value>Only 1 Heatbeat Received</value>
+    <value>Получен только один пакет heartbeat</value>
   </data>
   <data name="Only1HbD" xml:space="preserve">
-    <value>Only 1 Mavlink Heartbeat Packets was read from this port - Verify your hardware is setup correctly
-Mission Planner waits for 2 valid heartbeat packets before connecting</value>
+    <value>С этого порта получен лишь один пакет heartbeat. Проверьте корректность настройки оборудования.
+Mission Planner ожидает два корректных heartbeat перед подключением</value>
   </data>
   <data name="Trying" xml:space="preserve">
-    <value>Trying to connect.
-Timeout in {0}</value>
+    <value>Попытка подключения.
+Тайм-аут через {0}</value>
   </data>
   <data name="CantDetectBoardVersion" xml:space="preserve">
-    <value>Cant detect your Board version. Please check your cabling</value>
+    <value>Не удалось определить версию платы. Проверьте кабели</value>
   </data>
   <data name="CheckPortSettingsOr" xml:space="preserve">
-    <value>Check port settings or Port in use?</value>
+    <value>Проверьте настройки порта или занят ли порт</value>
   </data>
   <data name="CommunicationErrorNoConnection" xml:space="preserve">
-    <value>Communication Error - no connection</value>
+    <value>Ошибка связи — нет соединения</value>
   </data>
   <data name="DetectedA" xml:space="preserve">
     <value>Detected a </value>
@@ -457,22 +457,22 @@ Please use Standard/Advanced Params for the safe settings</value>
     <value>Start</value>
   </data>
   <data name="AreYouSureYouWantToUpload" xml:space="preserve">
-    <value>Are you sure you want to upload </value>
+    <value>Вы уверены, что хотите загрузить </value>
   </data>
   <data name="Beta" xml:space="preserve">
-    <value>Beta</value>
+    <value>Бета</value>
   </data>
   <data name="BetaWarning" xml:space="preserve">
-    <value>These are beta firmware, use at your own risk!!!</value>
+    <value>Это бета-прошивка, используйте на свой риск!!!</value>
   </data>
   <data name="CanNotConnectToComPortAnd" xml:space="preserve">
-    <value>Can not connect to com port and detect board type</value>
+    <value>Не удалось подключиться к COM-порту и определить тип платы</value>
   </data>
   <data name="Continue" xml:space="preserve">
-    <value>Continue</value>
+    <value>Продолжить</value>
   </data>
   <data name="ErrorUploadingFirmware" xml:space="preserve">
-    <value>Error uploading firmware</value>
+    <value>Ошибка загрузки прошивки</value>
   </data>
   <data name="QuestionMark" xml:space="preserve">
     <value>?</value>
@@ -481,176 +481,176 @@ Please use Standard/Advanced Params for the safe settings</value>
     <value>trunk</value>
   </data>
   <data name="TrunkWarning" xml:space="preserve">
-    <value>These are the latest trunk firmware, use at your own risk!!!</value>
+    <value>Это последняя версия trunk, используйте на свой риск!!!</value>
   </data>
   <data name="BadGPSHealth" xml:space="preserve">
-    <value>Unhealthy GPS Signal</value>
+    <value>Плохой сигнал GPS</value>
   </data>
   <data name="BadAirspeed" xml:space="preserve">
-    <value>Unhealthy Airspeed</value>
+    <value>Некорректное показание скорости</value>
   </data>
   <data name="BadGyroHealth" xml:space="preserve">
-    <value>Bad Gyro Health</value>
+    <value>Неисправность гироскопа</value>
   </data>
   <data name="BadAccelHealth" xml:space="preserve">
-    <value>Bad Accel Health</value>
+    <value>Неисправность акселерометра</value>
   </data>
   <data name="BadCompassHealth" xml:space="preserve">
-    <value>Bad Compass Health</value>
+    <value>Неисправность компаса</value>
   </data>
   <data name="BadBaroHealth" xml:space="preserve">
-    <value>Bad Baro Health</value>
+    <value>Неисправность барометра</value>
   </data>
   <data name="BadLiDARHealth" xml:space="preserve">
-    <value>Bad LiDAR Health</value>
+    <value>Неисправность LiDAR</value>
   </data>
   <data name="BadOptFlowHealth" xml:space="preserve">
-    <value>Bad OptFlow Health</value>
+    <value>Неисправность датчика оптического потока</value>
   </data>
   <data name="BadorNoTerrainData" xml:space="preserve">
-    <value>Bad or No Terrain Data</value>
+    <value>Некорректные или отсутствующие данные рельефа</value>
   </data>
   <data name="GeofenceBreach" xml:space="preserve">
-    <value>Geofence Breach</value>
+    <value>Нарушение геозоны</value>
   </data>
   <data name="BadAHRS" xml:space="preserve">
-    <value>Unhealthy AHRS</value>
+    <value>Некорректный AHRS</value>
   </data>
   <data name="NORCReceiver" xml:space="preserve">
-    <value>NO RC Receiver</value>
+    <value>Нет приёмника RC</value>
   </data>
   <data name="AutoWP" xml:space="preserve">
-    <value>Auto WP</value>
+    <value>Авто точка пути</value>
   </data>
   <data name="EnsurePropsNotOn" xml:space="preserve">
-    <value>Ensure your props are not on the Plane/Quad</value>
+    <value>Убедитесь, что пропеллеры сняты с аппарата</value>
   </data>
   <data name="FailSafe" xml:space="preserve">
     <value>FailSafe</value>
   </data>
   <data name="Error_binding" xml:space="preserve">
-    <value>Error binding</value>
+    <value>Ошибка привязки</value>
   </data>
   <data name="Put_the_transmitter_in_bind_mode__Receiver_is_waiting" xml:space="preserve">
-    <value>Put the transmitter in bind mode. Receiver is waiting.</value>
+    <value>Переведите передатчик в режим привязки. Приемник ожидает.</value>
   </data>
   <data name="Completed" xml:space="preserve">
-    <value>Completed</value>
+    <value>Завершено</value>
   </data>
   <data name="Click_when_Done" xml:space="preserve">
-    <value>Click when Done</value>
+    <value>Нажмите после завершения</value>
   </data>
   <data name="Saving" xml:space="preserve">
-    <value>Saving</value>
+    <value>Сохранение</value>
   </data>
   <data name="InvalidCert" xml:space="preserve">
-    <value>Invalid Cert</value>
+    <value>Неверный сертификат</value>
   </data>
   <data name="Note" xml:space="preserve">
-    <value>Note</value>
+    <value>Примечание</value>
   </data>
   <data name="PleaseUnplugTheBoardAnd" xml:space="preserve">
-    <value>Please unplug the board, and then press OK and plug back in.
-Mission Planner will look for 30 seconds to find the board</value>
+    <value>Отключите плату, затем нажмите OK и снова подключите её.
+Mission Planner будет искать плату 30 секунд</value>
   </data>
   <data name="ThisBoardHasBeenRetired" xml:space="preserve">
-    <value>This board has been retired, Mission Planner this will upload the last available version to your board (AC 3.2.1/AP 3.4.0)</value>
+    <value>Эта плата снята с поддержки. Mission Planner загрузит последнюю доступную версию (AC 3.2.1/AP 3.4.0)</value>
   </data>
   <data name="YouAreUsingUnsupportedHardware" xml:space="preserve">
-    <value>You are using unsupported hardware.
-This board does not contain a valid certificate of authenticity.
-Please contact your hardware vendor about signing your hardware.</value>
+    <value>Вы используете неподдерживаемое оборудование.
+На плате отсутствует действительный сертификат подлинности.
+Обратитесь к производителю для подписания оборудования.</value>
   </data>
   <data name="NoNeedToUpload" xml:space="preserve">
-    <value>No need to upload. already on the board</value>
+    <value>Загрузка не требуется: уже находится на плате</value>
   </data>
   <data name="PleaseWaitForTheMusicalTones" xml:space="preserve">
-    <value>Please wait for the musical tones to finish before clicking OK</value>
+    <value>Дождитесь окончания музыкальных тонов перед нажатием OK</value>
   </data>
   <data name="ObtainFromModule" xml:space="preserve">
-    <value>Obtain From Module</value>
+    <value>Получить из модуля</value>
   </data>
   <data name="SetHere" xml:space="preserve">
-    <value>Set Here</value>
+    <value>Установить здесь</value>
   </data>
   <data name="TrackerHome" xml:space="preserve">
-    <value>Tracker Home</value>
+    <value>Дом трекера</value>
   </data>
   <data name="velocity_variance" xml:space="preserve">
-    <value>velocity variance</value>
+    <value>разброс скорости</value>
   </data>
   <data name="compass_variance" xml:space="preserve">
-    <value>compass variance</value>
+    <value>разброс компаса</value>
   </data>
   <data name="pos_horiz_variance" xml:space="preserve">
-    <value>pos horiz variance</value>
+    <value>разброс гориз. положения</value>
   </data>
   <data name="pos_vert_variance" xml:space="preserve">
-    <value>pos vert variance</value>
+    <value>разброс по высоте</value>
   </data>
   <data name="terrain_alt_variance" xml:space="preserve">
-    <value>terrain alt variance</value>
+    <value>разброс высоты рельефа</value>
   </data>
   <data name="ChangeThrottle" xml:space="preserve">
-    <value>Change Throttle</value>
+    <value>Изменить газ</value>
   </data>
   <data name="Invalid_home_location" xml:space="preserve">
-    <value>Invalid home location</value>
+    <value>Недопустимая домашняя точка</value>
   </data>
   <data name="Converting_bin_to_log" xml:space="preserve">
-    <value>Converting bin to log</value>
+    <value>Конвертация bin в log</value>
   </data>
   <data name="UpdateNotFound" xml:space="preserve">
-    <value>No update available.</value>
+    <value>Обновлений нет.</value>
   </data>
   <data name="Failed_to_connect_to_SITL_instance" xml:space="preserve">
-    <value>Failed to connect to SITL instance</value>
+    <value>Не удалось подключиться к экземпляру SITL</value>
   </data>
   <data name="Scanning_File" xml:space="preserve">
-    <value>Scanning File</value>
+    <value>Сканирование файла</value>
   </data>
   <data name="Zoom_to_the_center_or_the_loaded_file" xml:space="preserve">
-    <value>Zoom to the center or the loaded file?</value>
+    <value>Приблизить к центру или к загруженному файлу?</value>
   </data>
   <data name="Zoom_To" xml:space="preserve">
-    <value>Zoom To</value>
+    <value>Приблизить к</value>
   </data>
   <data name="Do_you_want_to_load_this_into_the_flight_data_screen" xml:space="preserve">
-    <value>Do you want to load this into the flight data screen?</value>
+    <value>Загрузить это на экран телеметрии?</value>
   </data>
   <data name="Load_data" xml:space="preserve">
-    <value>Load data</value>
+    <value>Загрузить данные</value>
   </data>
   <data name="Bad_KML_File" xml:space="preserve">
-    <value>Bad KML File :</value>
+    <value>Некорректный файл KML :</value>
   </data>
   <data name="No_valid_heartbeats_read_from_port" xml:space="preserve">
-    <value>No valid heartbeats read from port</value>
+    <value>Нет корректных пакетов heartbeat с порта</value>
   </data>
   <data name="Bad_Vision_Position" xml:space="preserve">
-    <value>Bad Vision Position</value>
+    <value>Некорректная позиция по камере</value>
   </data>
   <data name="BadLogging" xml:space="preserve">
-    <value>Bad Logging</value>
+    <value>Ошибка ведения лога</value>
   </data>
   <data name="ParamRefreshRequired" xml:space="preserve">
-    <value>A Param refresh is required - Please press F5
-old #{0}  new #{1}</value>
+    <value>Требуется обновление параметров — нажмите F5
+старые #{0}  новые #{1}</value>
   </data>
   <data name="Failed_to_download_the_SITL_image" xml:space="preserve">
-    <value>Failed to download the SITL image.</value>
+    <value>Не удалось загрузить образ SITL.</value>
   </data>
   <data name="Not_available_when_used_as_a_windows_store_app" xml:space="preserve">
-    <value>Not available when used as a windows store app</value>
+    <value>Недоступно при использовании как приложение магазина Windows</value>
   </data>
   <data name="No_firmware_available_for_this_board" xml:space="preserve">
-    <value>No firmware available for this board!</value>
+    <value>Для этой платы прошивка недоступна!</value>
   </data>
   <data name="OnboardOSD" xml:space="preserve">
-    <value>Onboard OSD</value>
+    <value>Встроенный OSD</value>
   </data>
   <data name="User_Params" xml:space="preserve">
-    <value>User Params</value>
+    <value>Пользовательские параметры</value>
   </data>
   <data name="Planner" xml:space="preserve">
     <value>Планировщик</value>
@@ -659,25 +659,25 @@ old #{0}  new #{1}</value>
     <value>Отмена</value>
   </data>
   <data name="No_valid_sik_radio" xml:space="preserve">
-    <value>No valid sik radio</value>
+    <value>Нет корректного модема Sik</value>
   </data>
   <data name="MAVFtp" xml:space="preserve">
     <value>MAVFtp</value>
   </data>
   <data name="Bad_Battery" xml:space="preserve">
-    <value>Bad Battery</value>
+    <value>Плохая батарея</value>
   </data>
   <data name="Bad_Proximity" xml:space="preserve">
-    <value>Bad Proximity</value>
+    <value>Неисправность датчика приближения</value>
   </data>
   <data name="Bad_SatCom" xml:space="preserve">
-    <value>Bad SatCom</value>
+    <value>Неисправность спутниковой связи</value>
   </data>
   <data name="Prearm_check_failed" xml:space="preserve">
-    <value>Prearm check failed - check messages</value>
+    <value>Проверка перед взводом не пройдена — проверьте сообщения</value>
   </data>
   <data name="Invalid_Location" xml:space="preserve">
-    <value>Invalid Location</value>
+    <value>Некорректное местоположение</value>
   </data>
   <data name="Loading" xml:space="preserve">
     <value>Loading</value>

--- a/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.cs
+++ b/GCSViews/ConfigurationView/ConfigAccelerometerCalibration.cs
@@ -84,7 +84,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 _incalibrate = false;
                 Log.Error("Exception on level", ex);
-                CustomMessageBox.Show("Failed to level", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось выровнять", Strings.ERROR);
             }
         }
 
@@ -158,7 +158,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             catch (Exception ex)
             {
                 Log.Error("Exception on level", ex);
-                CustomMessageBox.Show("Failed to level", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось выровнять", Strings.ERROR);
             }
         }
 
@@ -180,7 +180,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             catch (Exception ex)
             {
                 Log.Error("Exception on simple accelerometer calibration", ex);
-                CustomMessageBox.Show("Failed to simple accelerometer calibration", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось выполнить простую калибровку акселерометра", Strings.ERROR);
             }
         }
     }

--- a/GCSViews/ConfigurationView/ConfigAdvanced.cs
+++ b/GCSViews/ConfigurationView/ConfigAdvanced.cs
@@ -88,7 +88,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private void but_anonlog_Click(object sender, System.EventArgs e)
         {
-            CustomMessageBox.Show("This is beta, please confirm the output file");
+            CustomMessageBox.Show("Это бета-версия, подтвердите выходной файл");
             using (OpenFileDialog ofd = new OpenFileDialog())
             {
                 ofd.Filter = "tlog or bin/log|*.tlog;*.bin;*.log";

--- a/GCSViews/ConfigurationView/ConfigAteryx.cs
+++ b/GCSViews/ConfigurationView/ConfigAteryx.cs
@@ -295,7 +295,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
                 if ((MainV2.comPort.MAV.cs.airspeed > 7.0) || (MainV2.comPort.MAV.cs.groundspeed > 10.0))
                 {
-                    CustomMessageBox.Show("Unable - UAV airborne");
+                    CustomMessageBox.Show("Невозможно – БПЛА в воздухе");
                     ((Button)sender).Enabled = true;
                     return;
                 }
@@ -305,7 +305,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("The Command failed to execute");
+                CustomMessageBox.Show("Не удалось выполнить команду");
             }
             ((Button)sender).Enabled = true;
         }
@@ -314,12 +314,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             try
             {
-                var dr = CustomMessageBox.Show("Reset Flash to Factory Defaults?", "Continue", MessageBoxButtons.YesNo);
+                var dr = CustomMessageBox.Show("Сбросить флэш к заводским настройкам?", "Продолжить", MessageBoxButtons.YesNo);
                 if (dr == (int)DialogResult.Yes)
                 {
                     if ((MainV2.comPort.MAV.cs.airspeed > 7.0) || (MainV2.comPort.MAV.cs.groundspeed > 7.0))
                     {
-                        MessageBox.Show("Unable - UAV airborne");
+                        MessageBox.Show("Невозможно – БПЛА в воздухе");
                         ((Button)sender).Enabled = true;
                         return;
                     }
@@ -329,7 +329,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("The Command failed to execute");
+                CustomMessageBox.Show("Не удалось выполнить команду");
             }
             ((Button)sender).Enabled = true;
         }

--- a/GCSViews/ConfigurationView/ConfigAteryxSensors.cs
+++ b/GCSViews/ConfigurationView/ConfigAteryxSensors.cs
@@ -47,7 +47,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
                 if ((MainV2.comPort.MAV.cs.airspeed > 7.0) || (MainV2.comPort.MAV.cs.groundspeed > 10.0))
                 {
-                    MessageBox.Show("Unable - UAV airborne");
+                    MessageBox.Show("Невозможно – БПЛА в воздухе");
                     ((Button)sender).Enabled = true;
                     return;
                 }
@@ -56,7 +56,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                MessageBox.Show("Failed to Zero Attitude");
+                MessageBox.Show("Не удалось сбросить ориентацию");
             }
             ((Button)sender).Enabled = true;
         }
@@ -69,7 +69,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
                 if ((MainV2.comPort.MAV.cs.airspeed > 7.0) || (MainV2.comPort.MAV.cs.groundspeed > 10.0))
                 {
-                    MessageBox.Show("Unable - UAV airborne");
+                    MessageBox.Show("Невозможно – БПЛА в воздухе");
                     ((Button)sender).Enabled = true;
                     return;
                 }
@@ -79,7 +79,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                MessageBox.Show("The Command failed to execute");
+                MessageBox.Show("Не удалось выполнить команду");
             }
             ((Button)sender).Enabled = true;
         }

--- a/GCSViews/ConfigurationView/ConfigBatteryMonitoring.cs
+++ b/GCSViews/ConfigurationView/ConfigBatteryMonitoring.cs
@@ -198,7 +198,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_CAPACITY Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT_CAPACITY", Strings.ERROR);
             }
         }
 
@@ -261,7 +261,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_MONITOR,BATT_VOLT_PIN,BATT_CURR_PIN Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT_MONITOR,BATT_VOLT_PIN,BATT_CURR_PIN", Strings.ERROR);
             }
         }
 
@@ -300,7 +300,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
                     (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
                      MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
-                   CustomMessageBox.Show("Set BATT_VOLT_MULT Failed", Strings.ERROR);
+                   CustomMessageBox.Show("Не удалось установить BATT_VOLT_MULT", Strings.ERROR);
                 }
             }
         }
@@ -324,7 +324,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
                     (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
                      MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
-                  CustomMessageBox.Show("Set BATT_VOLT_MULT Failed", Strings.ERROR);
+                  CustomMessageBox.Show("Не удалось установить BATT_VOLT_MULT", Strings.ERROR);
                 }
             }
         }
@@ -348,7 +348,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
                     (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
                      MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
-                  CustomMessageBox.Show("Set BATT_AMP_PERVOLT Failed", Strings.ERROR);
+                  CustomMessageBox.Show("Не удалось установить BATT_AMP_PERVOLT", Strings.ERROR);
                 }
             }
         }
@@ -558,7 +558,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT_????_PIN Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT_????_PIN", Strings.ERROR);
             }
         }
 
@@ -647,7 +647,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 if (MainV2.comPort.MAV.param.ContainsKey("BATT_MONITOR") &&
                     (MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 3 ||
                      MainV2.comPort.MAV.param["BATT_MONITOR"].Value == 4)) {
-                  CustomMessageBox.Show("Set BATT_AMP_PERVOLT Failed", Strings.ERROR);
+                  CustomMessageBox.Show("Не удалось установить BATT_AMP_PERVOLT", Strings.ERROR);
                 }
             }
         }

--- a/GCSViews/ConfigurationView/ConfigBatteryMonitoring2.cs
+++ b/GCSViews/ConfigurationView/ConfigBatteryMonitoring2.cs
@@ -84,7 +84,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT2_CAPACITY Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT2_CAPACITY", Strings.ERROR);
             }
         }
 
@@ -114,7 +114,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT2_VOLT_MULT Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT2_VOLT_MULT", Strings.ERROR);
             }
         }
 
@@ -128,7 +128,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT2_VOLT_MULT Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT2_VOLT_MULT", Strings.ERROR);
             }
         }
 
@@ -142,7 +142,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT2_AMP_PERVOL Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT2_AMP_PERVOL", Strings.ERROR);
             }
         }
 
@@ -247,7 +247,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set BATT2_AMP_PERVOL Failed", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось установить BATT2_AMP_PERVOL", Strings.ERROR);
             }
         }
     }

--- a/GCSViews/ConfigurationView/ConfigDroneCAN.cs
+++ b/GCSViews/ConfigurationView/ConfigDroneCAN.cs
@@ -500,7 +500,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     can.NodeInfo[nodeID].hardware_version.major + "." + can.NodeInfo[nodeID].hardware_version.minor,
                     CultureInfo.InvariantCulture);
 
-            if (CustomMessageBox.Show("Do you want to search the internet for an update?", "Update",
+            if (CustomMessageBox.Show("Хотите найти обновление в интернете?", "Обновление",
                     CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes)
             {
                 var url = can.LookForUpdate(devicename, hwversion, beta);
@@ -715,13 +715,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 menu_passthrough.Checked = false;
                 listener.Stop();
-                CustomMessageBox.Show("Stop", "Disabled forwarding");
+                CustomMessageBox.Show("Стоп", "Форвардинг отключён");
                 listener = null;
                 return;
             }
 
             var port = 500;
-            if (InputBox.Show("Enter TCP Port", "Enter TCP Port", ref port) == DialogResult.OK)
+            if (InputBox.Show("Введите TCP-порт", "Введите TCP-порт", ref port) == DialogResult.OK)
             {
                 menu_passthrough.Checked = true;
 
@@ -965,7 +965,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 menu_passthrough4.Checked = false;
                 listener.Stop();
-                CustomMessageBox.Show("Stop", "Disabled forwarding");
+                CustomMessageBox.Show("Стоп", "Форвардинг отключён");
                 listener = null;
                 return;
             }
@@ -974,12 +974,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             var baudrate = 230400;
             var target_node =
                 byte.Parse(myDataGridView1.CurrentRow.Cells[iDDataGridViewTextBoxColumn.Index].Value.ToString());
-            if (InputBox.Show("Enter TCP Port", "Enter TCP Port", ref port) != DialogResult.OK)
+            if (InputBox.Show("Введите TCP-порт", "Введите TCP-порт", ref port) != DialogResult.OK)
             {
                 return;
             }
 
-            if (InputBox.Show("Enter Baudrate", "Enter Baudrate", ref baudrate) != DialogResult.OK)
+            if (InputBox.Show("Введите скорость", "Введите скорость", ref baudrate) != DialogResult.OK)
             {
                 return;
             }
@@ -1480,7 +1480,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             if (inter == null)
             {
-                CustomMessageBox.Show("No network interfaces found");
+                CustomMessageBox.Show("Сетевые интерфейсы не найдены");
                 return;
             }
             BusInUse = bus;
@@ -1489,7 +1489,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             var p = inter.GetIPProperties().GetIPv4Properties();
             if (p == null)
             {
-                CustomMessageBox.Show("No IPv4 properties found");
+                CustomMessageBox.Show("Свойства IPv4 не найдены");
                 return;
             }
 

--- a/GCSViews/ConfigurationView/ConfigESCCalibration.cs
+++ b/GCSViews/ConfigurationView/ConfigESCCalibration.cs
@@ -31,13 +31,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 if (!MainV2.comPort.setParam((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, "ESC_CALIBRATION", 3))
                 {
-                    CustomMessageBox.Show("Set param error. Please ensure your version is AC3.3+.");
+                    CustomMessageBox.Show("Ошибка установки параметра. Убедитесь, что версия прошивки AC3.3+.");
                     return;
                 }
             }
             catch
             {
-                CustomMessageBox.Show("Set param error. Please ensure your version is AC3.3+.");
+                CustomMessageBox.Show("Ошибка установки параметра. Убедитесь, что версия прошивки AC3.3+.");
                 return;
             }
 

--- a/GCSViews/ConfigurationView/ConfigFirmware.cs
+++ b/GCSViews/ConfigurationView/ConfigFirmware.cs
@@ -540,7 +540,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                         if (fd.FileName.ToLower().EndsWith(".px4") || fd.FileName.ToLower().EndsWith(".apj"))
                         {
                             if (solo.Solo.is_solo_alive &&
-                                CustomMessageBox.Show("Solo", "Is this a Solo?",
+                                CustomMessageBox.Show("Solo", "Это устройство Solo?",
                                     CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes)
                             {
                                 boardtype = BoardDetect.boards.solo;

--- a/GCSViews/ConfigurationView/ConfigFirmwareDisabled.cs
+++ b/GCSViews/ConfigurationView/ConfigFirmwareDisabled.cs
@@ -22,20 +22,20 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!mav.BaseStream.IsOpen)
                 return;
 
-            if (CustomMessageBox.Show("Are you sure you want to upgrade the bootloader? This can brick your board",
-                "BL Update", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int) DialogResult.Yes)
+            if (CustomMessageBox.Show("Вы уверены, что хотите обновить загрузчик? Это может вывести плату из строя",
+                "Обновление загрузчика", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int) DialogResult.Yes)
                 if (CustomMessageBox.Show(
-                    "Are you sure you want to upgrade the bootloader? This can brick your board, Please allow 5 mins for this process",
-                    "BL Update", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int) DialogResult.Yes)
+                    "Вы уверены, что хотите обновить загрузчик? Это может вывести плату из строя. Процесс займёт около 5 минут",
+                    "Обновление загрузчика", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int) DialogResult.Yes)
                     try
                     {
                         if (mav.doCommand(MAVLink.MAV_CMD.FLASH_BOOTLOADER, 0, 0, 0, 0, 290876, 0, 0))
                         {
-                            CustomMessageBox.Show("Upgraded bootloader");
+                            CustomMessageBox.Show("Загрузчик обновлён");
                         }
                         else
                         {
-                            CustomMessageBox.Show("Failed to upgrade bootloader");
+                            CustomMessageBox.Show("Не удалось обновить загрузчик");
                         }
                     }
                     catch (Exception ex)

--- a/GCSViews/ConfigurationView/ConfigFirmwareManifest.cs
+++ b/GCSViews/ConfigurationView/ConfigFirmwareManifest.cs
@@ -347,13 +347,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 // allow scanning multiple ports
                 else
                 {
-                    CustomMessageBox.Show("Failed to discover board id. Please reconnect via usb and try again.", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось обнаружить идентификатор платы. Пожалуйста, переподключитесь по USB и повторите попытку.", Strings.ERROR);
                     return;
                 }
                 */
             }
 
-            CustomMessageBox.Show("Failed to detect port to upload to (Unknown VID/PID or Board String)\r\nPlease try Disconnect/Reconnect and upload while on this screen", Strings.ERROR);
+            CustomMessageBox.Show("Не удалось определить порт для загрузки (неизвестный VID/PID или строка платы)\r\nПожалуйста, отключитесь/подключитесь и выполняйте загрузку на этом экране", Strings.ERROR);
             return;
         }
 
@@ -439,7 +439,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                         else if (fd.FileName.ToLower().EndsWith(".hex"))
                         {
                             DFU.Progress = fw_Progress1;
-                            if (CustomMessageBox.Show("Do you want to upload this via DFU?", "", CustomMessageBox.MessageBoxButtons.OKCancel) == CustomMessageBox.DialogResult.OK)
+                            if (CustomMessageBox.Show("Загрузить через DFU?", "", CustomMessageBox.MessageBoxButtons.OKCancel) == CustomMessageBox.DialogResult.OK)
                             {
                                 DFU.Flash(fd.FileName);
                                 return;
@@ -448,14 +448,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                         else if(fd.FileName.ToLower().EndsWith(".bin"))
                         {
                             DFU.Progress = fw_Progress1;
-                            if (CustomMessageBox.Show("Flashing image to 0x08000000", "", CustomMessageBox.MessageBoxButtons.OKCancel) == CustomMessageBox.DialogResult.OK)
+                            if (CustomMessageBox.Show("Прошиваем образ по адресу 0x08000000", "", CustomMessageBox.MessageBoxButtons.OKCancel) == CustomMessageBox.DialogResult.OK)
                                 DFU.Flash(fd.FileName, 0x08000000);
                             return;
                         }
                         else if (fd.FileName.ToLower().EndsWith(".px4") || fd.FileName.ToLower().EndsWith(".apj"))
                         {
                             if (solo.Solo.is_solo_alive &&
-                                CustomMessageBox.Show("Solo", "Is this a Solo?",
+                                CustomMessageBox.Show("Solo", "Это устройство Solo?",
                                     CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes)
                             {
                                 boardtype = BoardDetect.boards.solo;
@@ -528,7 +528,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Failed to connect and send the reboot command", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось подключиться и отправить команду перезагрузки", Strings.ERROR);
             }
         }
 
@@ -541,21 +541,21 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (mav.BaseStream == null || !mav.BaseStream.IsOpen)
             {
-                CustomMessageBox.Show("Failed to find device on mavlink");
+                CustomMessageBox.Show("Не удалось обнаружить устройство через MAVLink");
                 return;
             }
 
-            if (CustomMessageBox.Show("Are you sure you want to upgrade the bootloader? This can brick your board",
-                    "BL Update", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
-                if (CustomMessageBox.Show("Are you sure you want to upgrade the bootloader? This can brick your board, Please allow 5 mins for this process",
-                        "BL Update", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
+            if (CustomMessageBox.Show("Вы уверены, что хотите обновить загрузчик? Это может вывести плату из строя",
+                    "Обновление загрузчика", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
+                if (CustomMessageBox.Show("Вы уверены, что хотите обновить загрузчик? Это может вывести плату из строя. Процесс займёт около 5 минут",
+                        "Обновление загрузчика", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
                     if (mav.doCommand(MAVLink.MAV_CMD.FLASH_BOOTLOADER, 0, 0, 0, 0, 290876, 0, 0))
                     {
-                        CustomMessageBox.Show("Upgraded bootloader");
+                        CustomMessageBox.Show("Загрузчик обновлён");
                     }
                     else
                     {
-                        CustomMessageBox.Show("Failed to upgrade bootloader");
+                        CustomMessageBox.Show("Не удалось обновить загрузчик");
                     }
 
             mav?.Close();

--- a/GCSViews/ConfigurationView/ConfigHWCompass.cs
+++ b/GCSViews/ConfigurationView/ConfigHWCompass.cs
@@ -392,7 +392,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 if (MainV2.comPort.MAV.param["COMPASS_AUTODEC"] == null)
                 {
-                    CustomMessageBox.Show("Not Available on " + MainV2.comPort.MAV.cs.firmware);
+                    CustomMessageBox.Show("Недоступно на " + MainV2.comPort.MAV.cs.firmware);
                 }
                 else
                 {
@@ -401,7 +401,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set COMPASS_AUTODEC Failed");
+                CustomMessageBox.Show("Не удалось установить COMPASS_AUTODEC");
             }
         }
 
@@ -459,7 +459,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             catch (Exception ex)
             {
                 this.LogError(ex);
-                CustomMessageBox.Show("Failed to start MAG CAL, check the autopilot is still responding.\n" + ex.ToString(), Strings.ERROR);
+                CustomMessageBox.Show("Не удалось запустить калибровку магнитометра, проверьте отклик автопилота.\n" + ex.ToString(), Strings.ERROR);
                 return;
             }
 
@@ -633,7 +633,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 MainV2.comPort.setParam((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, "COMPASS_LEARN", 1);
 
                 if (
-                    CustomMessageBox.Show("is the FW version greater than APM:copter 3.01 or APM:Plane 2.74?", "",
+                    CustomMessageBox.Show("Версия прошивки выше APM:Copter 3.01 или APM:Plane 2.74?", "",
                         MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
                 {
                     CMB_compass1_orient.SelectedIndex = (int)Rotation.ROTATION_NONE;
@@ -713,7 +713,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 if (MainV2.comPort.MAV.param["COMPASS_LEARN"] == null)
                 {
-                    CustomMessageBox.Show("Not Available on " + MainV2.comPort.MAV.cs.firmware);
+                    CustomMessageBox.Show("Недоступно на " + MainV2.comPort.MAV.cs.firmware);
                 }
                 else
                 {
@@ -722,7 +722,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set COMPASS_LEARN Failed");
+                CustomMessageBox.Show("Не удалось установить COMPASS_LEARN");
             }
         }
 

--- a/GCSViews/ConfigurationView/ConfigHWCompass2.cs
+++ b/GCSViews/ConfigurationView/ConfigHWCompass2.cs
@@ -140,7 +140,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (anymissing)
             {
-                CustomMessageBox.Show("Your compass configuration has changed, please review the missing compass", Strings.ERROR);
+                CustomMessageBox.Show("Конфигурация компаса изменилась, проверьте отсутствующий компас", Strings.ERROR);
             }
         }
 
@@ -158,14 +158,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (rebootrequired)
             {
-                if (CustomMessageBox.Show("Reboot required, reboot now?", "Reboot",
+                if (CustomMessageBox.Show("Требуется перезагрузка, перезагрузить сейчас?", "Перезагрузка",
                         CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes)
                 {
                     try
                     {
                         if (MainV2.comPort.doReboot())
                         {
-                            CustomMessageBox.Show("Reboot failed. please manually reboot the hardware.", Strings.ERROR);
+                            CustomMessageBox.Show("Не удалось перезагрузить. Перезагрузите устройство вручную.", Strings.ERROR);
                         }
                         rebootrequired = false;
                     }
@@ -275,7 +275,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             catch (Exception ex)
             {
                 this.LogError(ex);
-                CustomMessageBox.Show("Failed to start MAG CAL, check the autopilot is still responding.\n" + ex.ToString(), Strings.ERROR);
+                CustomMessageBox.Show("Не удалось запустить калибровку магнитометра, проверьте отклик автопилота.\n" + ex.ToString(), Strings.ERROR);
                 return;
             }
 
@@ -499,7 +499,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private void but_reboot_Click(object sender, EventArgs e)
         {
-            if (CustomMessageBox.Show("Reboot?") == CustomMessageBox.DialogResult.OK)
+            if (CustomMessageBox.Show("Перезагрузить?") == CustomMessageBox.DialogResult.OK)
             {
                 MainV2.comPort.doReboot(false, true);
                 rebootrequired = false;

--- a/GCSViews/ConfigurationView/ConfigHWOptFlow.cs
+++ b/GCSViews/ConfigurationView/ConfigHWOptFlow.cs
@@ -82,7 +82,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             {
                 if (MainV2.comPort.MAV.param["FLOW_ENABLE"] == null)
                 {
-                    CustomMessageBox.Show("Not Available on " + MainV2.comPort.MAV.cs.firmware);
+                    CustomMessageBox.Show("Недоступно на " + MainV2.comPort.MAV.cs.firmware);
                 }
                 else
                 {
@@ -91,7 +91,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Set FLOW_ENABLE Failed");
+                CustomMessageBox.Show("Не удалось установить FLOW_ENABLE");
             }
         }
 

--- a/GCSViews/ConfigurationView/ConfigInitialParams.cs
+++ b/GCSViews/ConfigurationView/ConfigInitialParams.cs
@@ -133,14 +133,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (prop_size <= 0 )
             {
 
-                CustomMessageBox.Show("Prop size must be larger than zero.", "ERROR!");
+                CustomMessageBox.Show("Размер пропеллера должен быть больше нуля.", "ОШИБКА!");
                 return;
 
             }
 
             if (batt_cells < 1)
             {
-                CustomMessageBox.Show("Battery cell count must be at least 1.", "ERROR!");
+                CustomMessageBox.Show("Количество ячеек батареи должно быть не меньше 1.", "ОШИБКА!");
                 return;
             }
 
@@ -222,13 +222,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             ThemeManager.ApplyThemeTo(paramCompareForm);
 
             MissionPlanner.Controls.MyButton button = paramCompareForm.Controls.Find("BUT_save", true).FirstOrDefault() as MissionPlanner.Controls.MyButton;
-            button.Text = "Write to FC";
+            button.Text = "Записать в контроллер";
             paramCompareForm.StartPosition = FormStartPosition.CenterParent;
             paramCompareForm.ShowDialog();
 
             if (paramCompareForm.DialogResult == DialogResult.OK)
             {
-                CustomMessageBox.Show("Initial Parameters succesfully updated.\r\nCheck parameters before flight!\r\n\r\nAfter test flight :\r\n\tSet ATC_THR_MIX_MAN to 0.5\r\n\tSet PSC_ACCZ_P to MOT_THST_HOVER\r\n\tSet PSC_ACCZ_I to 2*MOT_THST_HOVER\r\n\r\nHappy flying!", "Initial parameter calculator");
+                CustomMessageBox.Show("Начальные параметры успешно обновлены.\r\nПроверьте параметры перед полетом!\r\n\r\nПосле пробного полета:\r\n\tУстановите ATC_THR_MIX_MAN в 0.5\r\n\tУстановите PSC_ACCZ_P равным MOT_THST_HOVER\r\n\tУстановите PSC_ACCZ_I равным 2*MOT_THST_HOVER\r\n\r\nУдачных полетов!", "Калькулятор начальных параметров");
             }
 
             }

--- a/GCSViews/ConfigurationView/ConfigMotorTest.cs
+++ b/GCSViews/ConfigurationView/ConfigMotorTest.cs
@@ -298,7 +298,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to test motor\n" + ex);
+                CustomMessageBox.Show("Не удалось протестировать мотор\n" + ex);
             }
         }
 
@@ -317,7 +317,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                         0,
                         0))
                 {
-                    CustomMessageBox.Show("Command was denied by the autopilot");
+                    CustomMessageBox.Show("Команда была отклонена автопилотом");
                 }
             }
             catch
@@ -334,7 +334,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch
             {
-                CustomMessageBox.Show("Bad default system association", Strings.ERROR);
+                CustomMessageBox.Show("Неверная системная ассоциация", Strings.ERROR);
             }
         }
 
@@ -344,7 +344,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (!MainV2.comPort.MAV.param.ContainsKey("MOT_SPIN_ARM"))
             {
-                CustomMessageBox.Show("param MOT_SPIN_ARM missing", Strings.ERROR);
+                CustomMessageBox.Show("параметр MOT_SPIN_ARM отсутствует", Strings.ERROR);
                 return;
             }
 
@@ -372,7 +372,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             if (!MainV2.comPort.MAV.param.ContainsKey("MOT_SPIN_MIN"))
             {
-                CustomMessageBox.Show("param MOT_SPIN_MIN missing", Strings.ERROR);
+                CustomMessageBox.Show("параметр MOT_SPIN_MIN отсутствует", Strings.ERROR);
                 return;
             }
 

--- a/GCSViews/ConfigurationView/ConfigMount.cs
+++ b/GCSViews/ConfigurationView/ConfigMount.cs
@@ -162,7 +162,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to set Param\n" + ex);
+                CustomMessageBox.Show("Не удалось установить параметр\n" + ex);
                 Enabled = false;
             }
         }
@@ -366,7 +366,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to set Param\n" + ex);
+                CustomMessageBox.Show("Не удалось установить параметр\n" + ex);
             }
         }
 

--- a/GCSViews/ConfigurationView/ConfigOSD.cs
+++ b/GCSViews/ConfigurationView/ConfigOSD.cs
@@ -238,7 +238,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
         private void DiscardChanges()
         {
-            if ((int)DialogResult.OK == CustomMessageBox.Show("Are you sure?", MessageBoxButtons: MessageBoxButtons.OKCancel))
+            if ((int)DialogResult.OK == CustomMessageBox.Show("Вы уверены?", MessageBoxButtons: MessageBoxButtons.OKCancel))
             {
                 foreach (var p in osdSettings)
                     p.DiscardChange();
@@ -250,7 +250,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!osdSettings.Any(o => o.Changed))
             {
                 if (!silent)
-                    CustomMessageBox.Show("No Changes to Write!");
+                    CustomMessageBox.Show("Нет изменений для записи!");
 
                 return;
             }
@@ -258,7 +258,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!CheckConnected())
                 return;
 
-            var dialog = new ProgressReporterDialogue() { StartPosition = FormStartPosition.CenterScreen, Text = "Writing changes..." };
+            var dialog = new ProgressReporterDialogue() { StartPosition = FormStartPosition.CenterScreen, Text = "Запись изменений..." };
 
             CancellationTokenSource cts = new CancellationTokenSource();
             var cancellationToken = cts.Token;
@@ -295,14 +295,14 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             if (!silent && null != failed)
             {
                 var failedParamsEnum = string.Join(", ", failed.Take(3)) + (failed.Count > 3 ? "..." : "");
-                CustomMessageBox.Show($"Write Failed for {failed.Count} params: {failedParamsEnum}");
+                CustomMessageBox.Show($"Не удалось записать {failed.Count} параметров: {failedParamsEnum}");
             }
         }
 
         private void RefreshParameters()
         {
             if (osdSettings.Any(o => o.Changed)
-                && (int)DialogResult.No == CustomMessageBox.Show("This will reset your changes. Continue?", MessageBoxButtons: MessageBoxButtons.YesNo))
+                && (int)DialogResult.No == CustomMessageBox.Show("Это сбросит ваши изменения. Продолжить?", MessageBoxButtons: MessageBoxButtons.YesNo))
                 return;
 
             if (!MainV2.comPort.BaseStream.IsOpen)

--- a/GCSViews/ConfigurationView/ConfigPlanner.cs
+++ b/GCSViews/ConfigurationView/ConfigPlanner.cs
@@ -800,7 +800,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
             ThemeManager.LoadTheme(CMB_theme.Text);
             ThemeManager.ApplyThemeTo(MainV2.instance);
-            CustomMessageBox.Show("You may need to select another tab or restart to see the full effect.");
+            CustomMessageBox.Show("Возможно, потребуется выбрать другую вкладку или перезапустить программу, чтобы увидеть результат.");
         }
 
         private void BUT_themecustom_Click(object sender, EventArgs e)

--- a/GCSViews/ConfigurationView/ConfigRadioInput.cs
+++ b/GCSViews/ConfigurationView/ConfigRadioInput.cs
@@ -324,11 +324,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             else
             {
-                CustomMessageBox.Show("Bad channel 1 input, canceling");
+                CustomMessageBox.Show("Неверный ввод канала 1, отмена");
                 return;
             }
 
-            CustomMessageBox.Show("Ensure all your sticks are centered and throttle is down, and click ok to continue");
+            CustomMessageBox.Show("Убедитесь, что все стики по центру и газ убран, затем нажмите OK для продолжения");
 
             MainV2.comPort.MAV.cs.UpdateCurrentSettings(currentStateBindingSource.UpdateDataSource(MainV2.comPort.MAV.cs), true, MainV2.comPort);
 
@@ -459,11 +459,11 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 try
                 {
                     MainV2.comPort.setParam((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, "SWITCH_ENABLE", 0);
-                    CustomMessageBox.Show("Disabled Dip Switchs");
+                    CustomMessageBox.Show("Дип-переключатели отключены");
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Error Disableing Dip Switch");
+                    CustomMessageBox.Show("Ошибка отключения дип-переключателя");
                 }
             }
         }

--- a/GCSViews/ConfigurationView/ConfigRawParams.cs
+++ b/GCSViews/ConfigurationView/ConfigRawParams.cs
@@ -303,7 +303,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             else if (temp.Count > maxdisplay)
             {
                 // Ask the user for confirmation without listing individual changes
-                if (CustomMessageBox.Show($"You are about to change {temp.Count} parameters. Are you sure you want to proceed?", "Confirm Parameter Changes",
+                if (CustomMessageBox.Show($"Вы собираетесь изменить {temp.Count} параметров. Продолжить?", "Подтверждение изменения параметров",
             CustomMessageBox.MessageBoxButtons.YesNo, CustomMessageBox.MessageBoxIcon.Information) !=
         CustomMessageBox.DialogResult.Yes)
                     return;
@@ -373,7 +373,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             //Check if reboot is required
             if (reboot)
             {
-               CustomMessageBox.Show("Reboot is required for some parameters to take effect.", "Reboot Required");
+               CustomMessageBox.Show("Для применения некоторых параметров требуется перезагрузка.", "Требуется перезагрузка");
             }
 
             if (MainV2.comPort.MAV.param.TotalReceived != MainV2.comPort.MAV.param.TotalReported )
@@ -980,7 +980,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         private void BUT_reset_params_Click(object sender, EventArgs e)
         {
             if (
-                CustomMessageBox.Show("Reset all parameters to default\nAre you sure!!", "Reset",
+                CustomMessageBox.Show("Сбросить все параметры по умолчанию?\nВы уверены!!", "Сброс",
                     MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
             {
                 try
@@ -992,7 +992,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
 
 
                     CustomMessageBox.Show(
-                        "Your board is now rebooting, You will be required to reconnect to the autopilot.");
+                        "Плата перезагружается. Необходимо заново подключиться к автопилоту.");
                 }
                 catch (Exception ex)
                 {

--- a/GCSViews/ConfigurationView/ConfigSecure.cs
+++ b/GCSViews/ConfigurationView/ConfigSecure.cs
@@ -264,7 +264,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 else
                 {
                     UpdateStatus("Загрузка прошивки не удалась", (int)0);
-                    CustomMessageBox.Show("Web request failed: " + fwresp.ReasonPhrase);
+                    CustomMessageBox.Show("Сбой веб-запроса: " + fwresp.ReasonPhrase);
                     Console.WriteLine(await fwresp.Content.ReadAsStringAsync());
                 }
             }

--- a/GCSViews/ConfigurationView/ConfigSerial.cs
+++ b/GCSViews/ConfigurationView/ConfigSerial.cs
@@ -54,7 +54,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                     }
                     catch(Exception ex)
                     {
-                        CustomMessageBox.Show("Error reading SerialOptionRules.json file: " + ex.Message);
+                        CustomMessageBox.Show("Ошибка чтения файла SerialOptionRules.json: " + ex.Message);
                     }
                 }
                 var baudOptions = ParameterMetaDataRepository.GetParameterOptionsInt("SERIAL1_BAUD", MainV2.comPort.MAV.cs.firmware.ToString());
@@ -475,7 +475,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 bool ans = MainV2.comPort.setParam((byte)MainV2.comPort.sysidcurrent, (byte)MainV2.comPort.compidcurrent, param_name, val);
                 if (!ans)
                 {
-                    CustomMessageBox.Show("Unable to set parameter " + param_name);
+                    CustomMessageBox.Show("Не удалось установить параметр " + param_name);
                     return false;
                 }
                 else
@@ -485,7 +485,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             else
             {
-                CustomMessageBox.Show("Parameter " + param_name + " not found");
+                CustomMessageBox.Show("Параметр " + param_name + " не найден");
                 return false;
             }
         }

--- a/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
+++ b/GCSViews/ConfigurationView/ConfigSerialInjectGPS.cs
@@ -441,12 +441,12 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 }
                 catch (Exception ex2)
                 {
-                    CustomMessageBox.Show("Error creating file to save base data into " + ex2.ToString());
+                    CustomMessageBox.Show("Ошибка создания файла для сохранения базовых данных: " + ex2.ToString());
                 }
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Error Connecting\nif using com0com please rename the ports to COM??\n" +
+                CustomMessageBox.Show("Ошибка подключения\nесли используется com0com, переименуйте порты в COM??\n" +
                                       ex.ToString());
                 return;
             }
@@ -463,7 +463,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 catch (Exception ex)
                 {
                     log.Error(ex);
-                    CustomMessageBox.Show("Error configuring\n" +
+                    CustomMessageBox.Show("Ошибка конфигурации\n" +
                                           ex.ToString());
                     return;
                 }
@@ -523,13 +523,13 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Utilities.Septentrio.FailedAckException)
             {
-                this.LogError("Automatic configuration of Septentrio receiver failed");
-                CustomMessageBox.Show("Automatic configuration of Septentrio receiver failed.");
+                this.LogError("Не удалось автоматически настроить приёмник Septentrio");
+                CustomMessageBox.Show("Не удалось автоматически настроить приёмник Septentrio.");
             }
             catch (InvalidOperationException)
             {
-                this.LogError("Septentrio fixed base position is invalid");
-                CustomMessageBox.Show("Septentrio fixed base position is invalid.");
+                this.LogError("Недопустимая фиксированная позиция Septentrio");
+                CustomMessageBox.Show("Недопустимая фиксированная позиция Septentrio.");
             }
             catch (FormatException)
             {
@@ -1220,7 +1220,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
         {
             if (MainV2.comPort.MAV.cs.Base == null)
             {
-                CustomMessageBox.Show("No valid base position determined by gps yet", Strings.ERROR);
+                CustomMessageBox.Show("Базовая позиция ещё не определена приёмником GPS", Strings.ERROR);
                 return;
             }
 
@@ -1373,7 +1373,7 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 catch (Exception ex)
                 {
                     log.Error(ex);
-                    CustomMessageBox.Show("Error configuring\n" +
+                    CustomMessageBox.Show("Ошибка конфигурации\n" +
                                           ex.ToString());
                     return;
                 }
@@ -1425,8 +1425,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Utilities.Septentrio.FailedAckException)
             {
-                this.LogError("Configuration of fixed position on Septentrio receiver failed");
-                CustomMessageBox.Show("Configuration of fixed position on Septentrio receiver failed.");
+                this.LogError("Не удалось настроить фиксированную позицию приёмника Septentrio");
+                CustomMessageBox.Show("Не удалось настроить фиксированную позицию приёмника Septentrio.");
             }
             catch (FormatException) { }
             catch (InvalidOperationException) { }
@@ -1442,8 +1442,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
                 Settings.Instance["SerialInjectGPS_SeptentrioFixedAltitude"] = input_septentriofixedaltitude.Text;
             } catch (Utilities.Septentrio.FailedAckException)
             {
-                this.LogError("Configuration of fixed position on Septentrio receiver failed");
-                CustomMessageBox.Show("Configuration of fixed position on Septentrio receiver failed.");
+                this.LogError("Не удалось настроить фиксированную позицию приёмника Septentrio");
+                CustomMessageBox.Show("Не удалось настроить фиксированную позицию приёмника Septentrio.");
             }
         }
 
@@ -1487,8 +1487,8 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Utilities.Septentrio.FailedAckException)
             {
-                this.LogError("Configuration of fixed position on Septentrio receiver failed");
-                CustomMessageBox.Show("Configuration of fixed position on Septentrio receiver failed.");
+                this.LogError("Не удалось настроить фиксированную позицию приёмника Septentrio");
+                CustomMessageBox.Show("Не удалось настроить фиксированную позицию приёмника Septentrio.");
             }
             catch (FormatException) { }
             catch (InvalidOperationException) { }
@@ -1559,9 +1559,9 @@ namespace MissionPlanner.GCSViews.ConfigurationView
             }
             catch (Utilities.Septentrio.FailedAckException)
             {
-                this.LogError("Configuration of RTCM interval on Septentrio receiver failed");
-                CustomMessageBox.Show("Configuration of RTCM interval on Septentrio receiver failed.");
-            } 
+                this.LogError("Не удалось настроить интервал RTCM на приёмнике Septentrio");
+                CustomMessageBox.Show("Не удалось настроить интервал RTCM на приёмнике Septentrio.");
+            }
             catch (FormatException ex) {
                 log.Error(ex.Message);
                 CustomMessageBox.Show(ex.Message);

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1022,10 +1022,10 @@ namespace MissionPlanner.GCSViews
             try
             {
                 var isitarmed = MainV2.comPort.MAV.cs.armed;
-                var action = MainV2.comPort.MAV.cs.armed ? "Disarm" : "Arm";
+                var action = MainV2.comPort.MAV.cs.armed ? "Разоружить" : "Взвести";
 
                 if (isitarmed)
-                    if (CustomMessageBox.Show("Are you sure you want to " + action, action,
+                    if (CustomMessageBox.Show("Вы уверены, что хотите " + action + "?", action,
                             CustomMessageBox.MessageBoxButtons.YesNo) !=
                         CustomMessageBox.DialogResult.Yes)
                         return;
@@ -1723,7 +1723,7 @@ namespace MissionPlanner.GCSViews
             }
 
             if (
-                CustomMessageBox.Show("Are you sure you want to do " + CMB_action.Text + " ?", "Action",
+                CustomMessageBox.Show("Вы уверены, что хотите выполнить " + CMB_action.Text + "?", "Действие",
                     MessageBoxButtons.YesNo) == (int) DialogResult.Yes)
             {
                 try
@@ -4803,8 +4803,8 @@ namespace MissionPlanner.GCSViews
                     }
 
                     if (CustomMessageBox.Show(
-                            "This will reset the onboard home position (effects RTL etc). Are you Sure?",
-                            "Are you sure?", CustomMessageBox.MessageBoxButtons.OKCancel) ==
+                            "Это сбросит координаты домашней точки на борту (повлияет на RTL и т. д.). Вы уверены?",
+                            "Вы уверены?", CustomMessageBox.MessageBoxButtons.OKCancel) ==
                         CustomMessageBox.DialogResult.OK)
                     {
                         MainV2.comPort.doCommandInt((byte) MainV2.comPort.sysidcurrent,

--- a/GCSViews/FlightPlanner.cs
+++ b/GCSViews/FlightPlanner.cs
@@ -613,7 +613,7 @@ namespace MissionPlanner.GCSViews
                 else
                 {
                     if (
-                        CustomMessageBox.Show("This will clear your existing points, Continue?", "Confirm",
+                        CustomMessageBox.Show("Это удалит текущие точки, продолжить?", "Подтверждение",
                             MessageBoxButtons.OKCancel) != (int) DialogResult.OK)
                     {
                         return;
@@ -624,11 +624,11 @@ namespace MissionPlanner.GCSViews
             IProgressReporterDialogue frmProgressReporter = new ProgressReporterDialogue
             {
                 StartPosition = FormStartPosition.CenterScreen,
-                Text = "Receiving WP's"
+                Text = "Приём точек"
             };
 
             frmProgressReporter.DoWork += getWPs;
-            frmProgressReporter.UpdateProgressAndStatus(-1, "Receiving WP's");
+            frmProgressReporter.UpdateProgressAndStatus(-1, "Приём точек");
 
             ThemeManager.ApplyThemeTo(frmProgressReporter);
 
@@ -647,7 +647,7 @@ namespace MissionPlanner.GCSViews
             if ((altmode) CMB_altmode.SelectedValue == altmode.Absolute)
             {
                 if ((int) DialogResult.No ==
-                    CustomMessageBox.Show("Absolute Alt is selected are you sure?", "Alt Mode",
+                    CustomMessageBox.Show("Выбрана абсолютная высота, вы уверены?", "Режим высоты",
                         MessageBoxButtons.YesNo))
                 {
                     CMB_altmode.SelectedValue = (int) altmode.Relative;
@@ -666,7 +666,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show("Your home location is invalid", Strings.ERROR);
+                CustomMessageBox.Show("Неверные координаты дома", Strings.ERROR);
                 return;
             }
 
@@ -680,7 +680,7 @@ namespace MissionPlanner.GCSViews
                     {
                         if (!double.TryParse(Commands[b, a].Value.ToString(), out answer))
                         {
-                            CustomMessageBox.Show("There are errors in your mission");
+                            CustomMessageBox.Show("В вашей миссии есть ошибки");
                             return;
                         }
                     }
@@ -838,7 +838,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Failed to get fence point", Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось получить точку ограждения", Strings.ERROR);
                 }
 
                 return;
@@ -846,13 +846,13 @@ namespace MissionPlanner.GCSViews
 
             if (MainV2.comPort.MAV.param["FENCE_ACTION"] == null || MainV2.comPort.MAV.param["FENCE_TOTAL"] == null)
             {
-                CustomMessageBox.Show("Not Supported");
+                CustomMessageBox.Show("Не поддерживается");
                 return;
             }
 
             if (int.Parse(MainV2.comPort.MAV.param["FENCE_TOTAL"].ToString()) <= 1)
             {
-                CustomMessageBox.Show("Nothing to download");
+                CustomMessageBox.Show("Нечего загружать");
                 return;
             }
 
@@ -870,7 +870,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Failed to get fence point", Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось получить точку ограждения", Strings.ERROR);
                     return;
                 }
             }
@@ -926,13 +926,13 @@ namespace MissionPlanner.GCSViews
 
             if (MainV2.comPort.MAV.param["RALLY_TOTAL"] == null)
             {
-                CustomMessageBox.Show("Not Supported");
+                CustomMessageBox.Show("Не поддерживается");
                 return;
             }
 
             if (int.Parse(MainV2.comPort.MAV.param["RALLY_TOTAL"].ToString()) < 1)
             {
-                CustomMessageBox.Show("Rally points - Nothing to download");
+                CustomMessageBox.Show("Точки сбора - нечего загружать");
                 return;
             }
 
@@ -955,7 +955,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Failed to get rally point", Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось получить точку сбора", Strings.ERROR);
                     return;
                 }
             }
@@ -1004,7 +1004,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Can't open file! " + ex);
+                CustomMessageBox.Show("Не удалось открыть файл! " + ex);
             }
         }
 
@@ -1086,7 +1086,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("A invalid entry has been detected\n" + ex.Message, Strings.ERROR);
+                CustomMessageBox.Show("Обнаружена неверная запись\n" + ex.Message, Strings.ERROR);
             }
 
             // remove more than 40 revisions
@@ -1107,7 +1107,7 @@ namespace MissionPlanner.GCSViews
         {
             if (selectedrow > Commands.RowCount)
             {
-                CustomMessageBox.Show("Invalid coord, How did you do this?");
+                CustomMessageBox.Show("Некорректные координаты, как вы это сделали?");
                 return;
             }
 
@@ -1166,7 +1166,7 @@ namespace MissionPlanner.GCSViews
 
                     if (pass == false)
                     {
-                        CustomMessageBox.Show("You must have a home altitude");
+                        CustomMessageBox.Show("Необходимо задать высоту дома");
                         string homealt = "100";
                         if (DialogResult.Cancel == InputBox.Show("Home Alt", "Home Altitude", ref homealt))
                             return;
@@ -1176,7 +1176,7 @@ namespace MissionPlanner.GCSViews
                     int results1;
                     if (!int.TryParse(TXT_DefaultAlt.Text, out results1))
                     {
-                        CustomMessageBox.Show("Your default alt is not valid");
+                        CustomMessageBox.Show("Значение высоты по умолчанию неверно");
                         return;
                     }
 
@@ -1234,7 +1234,7 @@ namespace MissionPlanner.GCSViews
                 }
                 else
                 {
-                    CustomMessageBox.Show("Invalid Home or wp Alt");
+                    CustomMessageBox.Show("Неверная высота дома или точки маршрута");
                     cell.Style.BackColor = Color.Red;
                 }
             }
@@ -1826,7 +1826,7 @@ namespace MissionPlanner.GCSViews
                         }
                         catch
                         {
-                            CustomMessageBox.Show("Error opening File", Strings.ERROR);
+                            CustomMessageBox.Show("Ошибка при открытии файла", Strings.ERROR);
                             return;
                         }
                     }
@@ -1841,7 +1841,7 @@ namespace MissionPlanner.GCSViews
                         }
                         catch
                         {
-                            CustomMessageBox.Show("Error opening File", Strings.ERROR);
+                            CustomMessageBox.Show("Ошибка при открытии файла", Strings.ERROR);
                             return;
                         }
                     }
@@ -1892,7 +1892,7 @@ namespace MissionPlanner.GCSViews
             if ((altmode) CMB_altmode.SelectedValue == altmode.Absolute)
             {
                 if ((int) DialogResult.No ==
-                    CustomMessageBox.Show("Absolute Alt is selected are you sure?", "Alt Mode",
+                    CustomMessageBox.Show("Выбрана абсолютная высота, вы уверены?", "Режим высоты",
                         MessageBoxButtons.YesNo))
                 {
                     CMB_altmode.SelectedValue = (int) altmode.Relative;
@@ -1901,7 +1901,7 @@ namespace MissionPlanner.GCSViews
 
             if ((MAVLink.MAV_MISSION_TYPE) cmb_missiontype.SelectedValue != MAVLink.MAV_MISSION_TYPE.MISSION)
             {
-                CustomMessageBox.Show("Only available for missions");
+                CustomMessageBox.Show("Доступно только для миссий");
                 return;
             }
 
@@ -1916,7 +1916,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show("Your home location is invalid", Strings.ERROR);
+                CustomMessageBox.Show("Неверные координаты дома", Strings.ERROR);
                 return;
             }
 
@@ -1930,7 +1930,7 @@ namespace MissionPlanner.GCSViews
                     {
                         if (!double.TryParse(Commands[b, a].Value.ToString(), out answer))
                         {
-                            CustomMessageBox.Show("There are errors in your mission");
+                            CustomMessageBox.Show("В вашей миссии есть ошибки");
                             return;
                         }
                     }
@@ -2125,7 +2125,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show("Failed to set FENCE_ACTION");
+                CustomMessageBox.Show("Не удалось установить FENCE_ACTION");
                 return;
             }
 
@@ -2136,7 +2136,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show("Failed to set FENCE_TOTAL");
+                CustomMessageBox.Show("Не удалось установить FENCE_TOTAL");
                 return;
             }
 
@@ -2232,7 +2232,7 @@ namespace MissionPlanner.GCSViews
             catch (Exception ex)
             {
                 log.Error(ex);
-                CustomMessageBox.Show("Map change failed. try zooming out first.");
+                CustomMessageBox.Show("Не удалось изменить карту. Попробуйте отдалить изображение.");
             }
         }
 
@@ -2278,7 +2278,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception)
             {
-                CustomMessageBox.Show("Row error");
+                CustomMessageBox.Show("Ошибка строки");
             }
         }
 
@@ -2310,7 +2310,7 @@ namespace MissionPlanner.GCSViews
                 catch (Exception ex)
                 {
                     log.Error(ex);
-                    CustomMessageBox.Show("Invalid Lat/Long, please fix", Strings.ERROR);
+                    CustomMessageBox.Show("Неверные координаты, исправьте", Strings.ERROR);
                 }
             }
 
@@ -2640,11 +2640,11 @@ namespace MissionPlanner.GCSViews
 
                 polygonsoverlay.Markers.Add(new GMarkerGoogle(MouseDownStart, GMarkerGoogleType.red));
                 MainMap.Invalidate();
-                CustomMessageBox.Show("Distance: " +
+                CustomMessageBox.Show("Расстояние: " +
                                       FormatDistance(
                                           MainMap.MapProvider.Projection.GetDistance(startmeasure, MouseDownStart),
                                           true) +
-                                      " AZ: " +
+                                      " Азимут: " +
                                       (MainMap.MapProvider.Projection.GetBearing(startmeasure, MouseDownStart)
                                           .ToString("0")));
                 polygonsoverlay.Polygons.Remove(line);
@@ -2878,25 +2878,25 @@ namespace MissionPlanner.GCSViews
             int altstep = 5;
             if (!int.TryParse(RadiusIn, out Radius))
             {
-                CustomMessageBox.Show("Bad Radius");
+                CustomMessageBox.Show("Неверный радиус");
                 return;
             }
 
             if (!int.TryParse(minaltin, out minalt))
             {
-                CustomMessageBox.Show("Bad min alt");
+                CustomMessageBox.Show("Неверная минимальная высота");
                 return;
             }
 
             if (!int.TryParse(maxaltin, out maxalt))
             {
-                CustomMessageBox.Show("Bad maxalt");
+                CustomMessageBox.Show("Неверная максимальная высота");
                 return;
             }
 
             if (!int.TryParse(altstepin, out altstep))
             {
-                CustomMessageBox.Show("Bad alt step");
+                CustomMessageBox.Show("Неверный шаг высоты");
                 return;
             }
 
@@ -2978,7 +2978,7 @@ namespace MissionPlanner.GCSViews
 
             if (!int.TryParse(RadiusIn, out Radius))
             {
-                CustomMessageBox.Show("Bad Radius");
+                CustomMessageBox.Show("Неверный радиус");
                 return;
             }
 
@@ -2986,19 +2986,19 @@ namespace MissionPlanner.GCSViews
 
             if (!int.TryParse(Pointsin, out Points))
             {
-                CustomMessageBox.Show("Bad Point value");
+                CustomMessageBox.Show("Неверное значение точки");
                 return;
             }
 
             if (!int.TryParse(Directionin, out Direction))
             {
-                CustomMessageBox.Show("Bad Direction value");
+                CustomMessageBox.Show("Неверное значение направления");
                 return;
             }
 
             if (!int.TryParse(startanglein, out startangle))
             {
-                CustomMessageBox.Show("Bad start angle value");
+                CustomMessageBox.Show("Неверное значение начального угла");
                 return;
             }
 
@@ -3126,7 +3126,7 @@ namespace MissionPlanner.GCSViews
                     catch (Exception ex)
                     {
                         log.Error(ex);
-                        CustomMessageBox.Show("error selecting wp, please try again.");
+                        CustomMessageBox.Show("Ошибка выбора точки, повторите попытку.");
                     }
                 }
                 else if (int.TryParse(CurentRectMarker.InnerMarker.Tag.ToString().Replace("grid", ""), out no))
@@ -3162,7 +3162,7 @@ namespace MissionPlanner.GCSViews
                     catch (Exception ex)
                     {
                         log.Error(ex);
-                        CustomMessageBox.Show("error selecting wp, please try again.");
+                        CustomMessageBox.Show("Ошибка выбора точки, повторите попытку.");
                     }
                 }
 
@@ -3623,7 +3623,7 @@ namespace MissionPlanner.GCSViews
                 }
             }
             redrawPolygonSurvey(currentWaypoints);
-            if (CustomMessageBox.Show("Clear current waypoints?", "Confirm",
+            if (CustomMessageBox.Show("Очистить текущие точки маршрута?", "Подтверждение",
                                        MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
             {
                 clearMissionToolStripMenuItem_Click(null, null);  // perhaps not best practice to directly call "click" events
@@ -3712,25 +3712,25 @@ namespace MissionPlanner.GCSViews
             if (!MainV2.comPort.MAV.param.ContainsKey("FENCE_ENABLE") &&
                 !MainV2.comPort.MAV.param.ContainsKey("FENCE_ACTION"))
             {
-                CustomMessageBox.Show("Not Supported");
+                CustomMessageBox.Show("Не поддерживается");
                 return;
             }
 
             if (drawnpolygon == null)
             {
-                CustomMessageBox.Show("No polygon to upload");
+                CustomMessageBox.Show("Полигон не задан");
                 return;
             }
 
             if (geofenceoverlay.Markers.Count == 0)
             {
-                CustomMessageBox.Show("No return location set");
+                CustomMessageBox.Show("Не указана точка возврата");
                 return;
             }
 
             if (drawnpolygon.Points.Count == 0)
             {
-                CustomMessageBox.Show("No polygon drawn");
+                CustomMessageBox.Show("Полигон не нарисован");
                 return;
             }
 
@@ -3743,7 +3743,7 @@ namespace MissionPlanner.GCSViews
                 !pnpoly(plll.ToArray(), geofenceoverlay.Markers[0].Position.Lat,
                     geofenceoverlay.Markers[0].Position.Lng))
             {
-                CustomMessageBox.Show("Your return location is outside the polygon");
+                CustomMessageBox.Show("Точка возврата находится вне полигона");
                 return;
             }
 
@@ -3761,7 +3761,7 @@ namespace MissionPlanner.GCSViews
 
                 if (!int.TryParse(minalts, out minalt))
                 {
-                    CustomMessageBox.Show("Bad Min Alt");
+                    CustomMessageBox.Show("Неверная минимальная высота");
                     return;
                 }
             }
@@ -3777,7 +3777,7 @@ namespace MissionPlanner.GCSViews
 
                 if (!int.TryParse(maxalts, out maxalt))
                 {
-                    CustomMessageBox.Show("Bad Max Alt");
+                    CustomMessageBox.Show("Неверная максимальная высота");
                     return;
                 }
             }
@@ -3794,7 +3794,7 @@ namespace MissionPlanner.GCSViews
             catch (Exception ex)
             {
                 log.Error(ex);
-                CustomMessageBox.Show("Failed to set min/max fence alt");
+                CustomMessageBox.Show("Не удалось установить min/max высоты забора");
                 return;
             }
 
@@ -3847,7 +3847,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Failed to restore FENCE_ACTION");
+                    CustomMessageBox.Show("Не удалось восстановить FENCE_ACTION");
                     return;
                 }
 
@@ -3886,7 +3886,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to send new fence points " + ex, Strings.ERROR);
+                CustomMessageBox.Show("Не удалось отправить новые точки забора " + ex, Strings.ERROR);
             }
         }
 
@@ -4048,7 +4048,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("SPLINE_WAYPOINT command not supported.");
+                    CustomMessageBox.Show("Команда SPLINE_WAYPOINT не поддерживается.");
                     Commands.Rows.RemoveAt(selectedrow);
                     return;
                 }
@@ -4071,7 +4071,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Invalid insert position", Strings.ERROR);
+                    CustomMessageBox.Show("Неверная позиция вставки", Strings.ERROR);
                     return;
                 }
 
@@ -4316,7 +4316,7 @@ namespace MissionPlanner.GCSViews
             }
             catch
             {
-                CustomMessageBox.Show("Failed to open url http://127.0.0.1:56781/network.kml");
+                CustomMessageBox.Show("Не удалось открыть URL http://127.0.0.1:56781/network.kml");
             }
         }
 
@@ -4722,7 +4722,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Error opening File", Strings.ERROR);
+                    CustomMessageBox.Show("Ошибка при открытии файла", Strings.ERROR);
                     return;
                 }
             }
@@ -6541,7 +6541,7 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
 
             if (!int.TryParse(alt, out alti))
             {
-                MessageBox.Show("Bad Alt");
+                MessageBox.Show("Неверная высота");
                 return;
             }
 
@@ -6558,7 +6558,7 @@ Column 1: Field type (RALLY is the only one at the moment -- may have RALLY_LAND
 
                 if (!int.TryParse(top, out topi))
                 {
-                    MessageBox.Show("Bad Takeoff pitch");
+                    MessageBox.Show("Неверный угол взлёта");
                     return;
                 }
             }

--- a/GCSViews/Help.cs
+++ b/GCSViews/Help.cs
@@ -71,7 +71,7 @@ namespace MissionPlanner.GCSViews
                 if (Control.ModifierKeys == Keys.Control)
                 {
                     Utilities.Update.domaster = true;
-                    CustomMessageBox.Show("This will update to MASTER release");
+                    CustomMessageBox.Show("Будет выполнено обновление до версии MASTER");
                 }
 
                 Utilities.Update.DoUpdate();

--- a/GCSViews/SITL.cs
+++ b/GCSViews/SITL.cs
@@ -170,7 +170,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to download and start sitl\n" + ex.ToString());
+                CustomMessageBox.Show("Не удалось загрузить и запустить SITL\n" + ex.ToString());
             }
         }
 
@@ -191,7 +191,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to download and start sitl\n" + ex.ToString());
+                CustomMessageBox.Show("Не удалось загрузить и запустить SITL\n" + ex.ToString());
             }
         }
 
@@ -212,7 +212,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to download and start sitl\n" + ex.ToString());
+                CustomMessageBox.Show("Не удалось загрузить и запустить SITL\n" + ex.ToString());
             }
         }
 
@@ -233,7 +233,7 @@ namespace MissionPlanner.GCSViews
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Failed to download and start sitl\n" + ex.ToString());
+                CustomMessageBox.Show("Не удалось загрузить и запустить SITL\n" + ex.ToString());
             }
         }
 
@@ -675,7 +675,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch (Exception ex)
                 {
-                    CustomMessageBox.Show("Failed to start the simulator\n" + ex.ToString(), Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось запустить симулятор\n" + ex.ToString(), Strings.ERROR);
                     return;
                 }
             }
@@ -703,7 +703,7 @@ namespace MissionPlanner.GCSViews
                 }
                 catch (Exception ex)
                 {
-                    CustomMessageBox.Show("Failed to start the simulator\n" + ex.ToString(), Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось запустить симулятор\n" + ex.ToString(), Strings.ERROR);
                     return;
                 }
             }

--- a/Grid/GridPlugin.cs
+++ b/Grid/GridPlugin.cs
@@ -47,7 +47,7 @@ namespace MissionPlanner.Grid
                 else
                 {
                     if (
-                        CustomMessageBox.Show("No polygon defined. Load a file?", "Load File", MessageBoxButtons.YesNo) ==
+                        CustomMessageBox.Show("Полигон не определён. Загрузить файл?", "Загрузить файл", MessageBoxButtons.YesNo) ==
                         (int)DialogResult.Yes)
                     {
                         gridui.LoadGrid();

--- a/Grid/GridUI.cs
+++ b/Grid/GridUI.cs
@@ -1594,7 +1594,11 @@ namespace MissionPlanner.Grid
                 camera.sensorheight = float.Parse(TXT_sensheight.Text);
                 camera.sensorwidth = float.Parse(TXT_senswidth.Text);
             }
-            catch { CustomMessageBox.Show("One of your entries is not a valid number"); return; }
+            catch
+            {
+                CustomMessageBox.Show("Одно из введённых значений некорректно");
+                return;
+            }
 
             cameras[CMB_camera.Text] = camera;
 
@@ -1609,7 +1613,7 @@ namespace MissionPlanner.Grid
 
                 if (NUM_split.Value > 1 && CHK_toandland.Checked != true)
                 {
-                    CustomMessageBox.Show("You must use Land/RTL to split a mission", Strings.ERROR);
+                    CustomMessageBox.Show("Для разделения миссии необходимо использовать Land/RTL", Strings.ERROR);
                     return;
                 }
 

--- a/Log/LogBrowse.cs
+++ b/Log/LogBrowse.cs
@@ -1561,7 +1561,7 @@ main()
                         log.Info("Bad Data : " + type + " " + col + " " + a);
                         if (error >= 500)
                         {
-                            CustomMessageBox.Show("There is to much bad data - failing");
+                            CustomMessageBox.Show("Слишком много поврежденных данных — остановка");
                             break;
                         }
                     }

--- a/Log/LogDownload.cs
+++ b/Log/LogDownload.cs
@@ -124,7 +124,7 @@ namespace MissionPlanner.Log
             catch (Exception ex)
             {
                 log.Error("Error opening comport", ex);
-                CustomMessageBox.Show("Error opening comport");
+                CustomMessageBox.Show("Ошибка открытия порта");
                 return;
             }
 
@@ -284,7 +284,7 @@ namespace MissionPlanner.Log
                                 {
                                     log.Error(ex);
                                     CustomMessageBox.Show(
-                                        "Failed to rename file " + logfile + "\nto " + newlogfilename, Strings.ERROR);
+                                        "Не удалось переименовать файл " + logfile + "\nв " + newlogfilename, Strings.ERROR);
                                 }
                             }
 
@@ -294,7 +294,7 @@ namespace MissionPlanner.Log
 
                             this.Invoke(
                                 (System.Windows.Forms.MethodInvoker)
-                                    delegate () { TXT_seriallog.AppendText("Creating KML for " + logfile); });
+                                    delegate () { TXT_seriallog.AppendText("Создание KML для " + logfile); });
 
                             LogOutput lo = new LogOutput();
 
@@ -394,7 +394,7 @@ namespace MissionPlanner.Log
             }
             catch (Exception ex)
             {
-                CustomMessageBox.Show("Error reading data" + ex.ToString());
+                CustomMessageBox.Show("Ошибка чтения данных" + ex.ToString());
             }
         }
 
@@ -420,7 +420,7 @@ namespace MissionPlanner.Log
             {
                 if (CHK_logs.Items.Count == 0)
                 {
-                    CustomMessageBox.Show("Nothing to download");
+                    CustomMessageBox.Show("Нечего загружать");
                     return;
                 }
 
@@ -542,7 +542,7 @@ namespace MissionPlanner.Log
                 {
                     foreach (string logfile in openFileDialog1.FileNames)
                     {
-                        TXT_seriallog.AppendText("\n\nProcessing " + logfile + "\n");
+                        TXT_seriallog.AppendText("\n\nОбработка " + logfile + "\n");
                         this.Refresh();
                         LogOutput lo = new LogOutput();
                         try
@@ -557,13 +557,13 @@ namespace MissionPlanner.Log
                         }
                         catch (Exception ex)
                         {
-                            CustomMessageBox.Show("Error processing file. Make sure the file is not in use.\n" +
+                            CustomMessageBox.Show("Ошибка обработки файла. Убедитесь, что файл не используется.\n" +
                                                   ex.ToString());
                         }
 
                         lo.writeKML(logfile + ".kml");
 
-                        TXT_seriallog.AppendText("Done\n");
+                        TXT_seriallog.AppendText("Готово\n");
                     }
                 }
             }
@@ -590,7 +590,7 @@ namespace MissionPlanner.Log
                 {
                     foreach (string logfile in openFileDialog1.FileNames)
                     {
-                        TXT_seriallog.AppendText("\n\nProcessing " + logfile + "\n");
+                        TXT_seriallog.AppendText("\n\nОбработка " + logfile + "\n");
                         this.Refresh();
 
                         LogOutput lo = new LogOutput();
@@ -609,13 +609,13 @@ namespace MissionPlanner.Log
                         }
                         catch (Exception ex)
                         {
-                            CustomMessageBox.Show("Error processing log. Is it still downloading? " + ex.Message);
+                            CustomMessageBox.Show("Ошибка обработки лога. Он ещё загружается? " + ex.Message);
                             continue;
                         }
 
                         lo.writeKMLFirstPerson(logfile + "-fp.kml");
 
-                        TXT_seriallog.AppendText("Done\n");
+                        TXT_seriallog.AppendText("Готово\n");
                     }
                 }
             }

--- a/Log/LogStrings.resx
+++ b/Log/LogStrings.resx
@@ -118,51 +118,51 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CancelDownload" xml:space="preserve">
-    <value>You are downloading a log file, do you want to cancel?</value>
+    <value>Вы загружаете файл журнала, отменить?</value>
   </data>
   <data name="Confirmation" xml:space="preserve">
-    <value>Are you sure?</value>
+    <value>Вы уверены?</value>
   </data>
   <data name="CreatingKmlPrompt" xml:space="preserve">
-    <value>Creating KML for {0}</value>
+    <value>Создание KML для {0}</value>
   </data>
   <data name="Done" xml:space="preserve">
-    <value>Done</value>
+    <value>Готово</value>
   </data>
   <data name="DownloadStarting" xml:space="preserve">
-    <value>Downloading log files to: {0}</value>
+    <value>Загрузка журналов в: {0}</value>
   </data>
   <data name="EraseComplete" xml:space="preserve">
-    <value>!!Allow 30-90 seconds for erase</value>
+    <value>!!Дождитесь завершения очистки (30–90 секунд)</value>
   </data>
   <data name="ErrorProcessingLogfile" xml:space="preserve">
-    <value>Error processing file. Make sure the file is not in use</value>
+    <value>Ошибка обработки файла. Убедитесь, что файл не используется</value>
   </data>
   <data name="FetchingLog" xml:space="preserve">
-    <value>Fetching log file {0} ...</value>
+    <value>Получение файла журнала {0} ...</value>
   </data>
   <data name="FetchingLogfileList" xml:space="preserve">
-    <value>Getting list of log files...</value>
+    <value>Получение списка журналов...</value>
   </data>
   <data name="LogDirectoryError" xml:space="preserve">
-    <value>Could not create log file directory: {0}</value>
+    <value>Не удалось создать каталог журналов: {0}</value>
   </data>
   <data name="NoLogsFound" xml:space="preserve">
-    <value>No logs to download</value>
+    <value>Журналов для загрузки нет</value>
   </data>
   <data name="NotConnected" xml:space="preserve">
-    <value>Please connect your drone</value>
+    <value>Подключите дрон</value>
   </data>
   <data name="NothingSelected" xml:space="preserve">
-    <value>Please select some logs by checking the check boxes in the list</value>
+    <value>Выберите журналы, отмечая галочки в списке</value>
   </data>
   <data name="ProcessingLog" xml:space="preserve">
-    <value>Processing {0}</value>
+    <value>Обработка {0}</value>
   </data>
   <data name="SomeLogsFound" xml:space="preserve">
-    <value>Found {0} log files, note: item sizes are just an estimate.</value>
+    <value>Найдено {0} файлов журнала, размеры указаны приблизительно.</value>
   </data>
   <data name="UnhandledException" xml:space="preserve">
-    <value>Error:</value>
+    <value>Ошибка:</value>
   </data>
 </root>

--- a/MainV2.cs
+++ b/MainV2.cs
@@ -1023,7 +1023,7 @@ namespace MissionPlanner
 
             if (CurrentState.rateattitudebackup == 0) // initilised to 10, configured above from save
             {
-                CustomMessageBox.Show("NOTE: your attitude rate is 0, the hud will not work\nChange in Configuration > Planner > Telemetry Rates");
+                CustomMessageBox.Show("ВНИМАНИЕ: частота обновления углов равна 0, HUD не будет работать\nИзмените в Конфигурации > Планировщик > Скорости телеметрии");
             }
 
             // create log dir if it doesnt exist
@@ -1057,7 +1057,7 @@ namespace MissionPlanner
 
                     if (Framework < 4.0)
                     {
-                        CustomMessageBox.Show("This program requires .NET Framework 4.0. You currently have " + Framework);
+                        CustomMessageBox.Show("Для работы программы требуется .NET Framework 4.0. У вас установлена версия " + Framework);
                     }
                 }
                 catch (Exception ex)
@@ -1315,14 +1315,14 @@ namespace MissionPlanner
             else
             {
                 var pw = "";
-                if (InputBox.Show("Enter Password", "Please enter your password", ref pw, true) ==
+                if (InputBox.Show("Введите пароль", "Пожалуйста, введите пароль", ref pw, true) ==
                     System.Windows.Forms.DialogResult.OK)
                 {
                     bool ans = Password.ValidatePassword(pw);
 
                     if (ans == false)
                     {
-                        CustomMessageBox.Show("Bad Password", "Bad Password");
+                        CustomMessageBox.Show("Неверный пароль", "Неверный пароль");
                     }
                 }
 
@@ -1347,14 +1347,14 @@ namespace MissionPlanner
             else
             {
                 var pw = "";
-                if (InputBox.Show("Enter Password", "Please enter your password", ref pw, true) ==
+                if (InputBox.Show("Введите пароль", "Пожалуйста, введите пароль", ref pw, true) ==
                     System.Windows.Forms.DialogResult.OK)
                 {
                     bool ans = Password.ValidatePassword(pw);
 
                     if (ans == false)
                     {
-                        CustomMessageBox.Show("Bad Password", "Bad Password");
+                        CustomMessageBox.Show("Неверный пароль", "Неверный пароль");
                     }
                 }
 
@@ -1816,7 +1816,7 @@ namespace MissionPlanner
                     log.Warn(ex2);
                 }
 
-                CustomMessageBox.Show($"Can not establish a connection\n\n{ex.Message}");
+                CustomMessageBox.Show($"Невозможно установить соединение\n\n{ex.Message}");
                 return;
             }
         }
@@ -2834,7 +2834,7 @@ namespace MissionPlanner
                                         (Action)
                                         delegate
                                         {
-                                            CustomMessageBox.Show("Failed to update home location (" +
+                                            CustomMessageBox.Show("Не удалось обновить домашнюю точку (" +
                                                                   MainV2.comPort.MAV.sysid + ")");
                                         });
                                 }
@@ -3681,7 +3681,7 @@ namespace MissionPlanner
                         }
                         catch (Exception ex)
                         {
-                            CustomMessageBox.Show("Start script failed: " + ex.ToString(), Strings.ERROR);
+                            CustomMessageBox.Show("Не удалось запустить скрипт: " + ex.ToString(), Strings.ERROR);
                         }
                     });
                 }
@@ -3714,7 +3714,7 @@ namespace MissionPlanner
                     }
                     else
                     {
-                        CustomMessageBox.Show("Failed to start joystick");
+                        CustomMessageBox.Show("Не удалось запустить джойстик");
                     }
                 }
 
@@ -4157,13 +4157,13 @@ namespace MissionPlanner
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Invalid command");
+                    CustomMessageBox.Show("Неверная команда");
                     return true;
                 }
 
                 //read
                 ///////MainV2.comPort.doCommand(MAVLink09.MAV_CMD.PREFLIGHT_STORAGE, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f);
-                CustomMessageBox.Show("Done MAV_ACTION_STORAGE_WRITE");
+                CustomMessageBox.Show("Команда MAV_ACTION_STORAGE_WRITE выполнена");
                 return true;
             }
 
@@ -4412,7 +4412,7 @@ namespace MissionPlanner
             }
             catch
             {
-                CustomMessageBox.Show("Link open failed. check your default webpage association");
+                CustomMessageBox.Show("Не удалось открыть ссылку. Проверьте ассоциацию веб-страниц по умолчанию");
             }
         }
 
@@ -4658,7 +4658,7 @@ namespace MissionPlanner
             }
             catch
             {
-                CustomMessageBox.Show("Failed to open url https://ardupilot.org");
+                CustomMessageBox.Show("Не удалось открыть ссылку https://ardupilot.org");
             }
         }
 

--- a/NoFly/NoFly.cs
+++ b/NoFly/NoFly.cs
@@ -72,7 +72,7 @@ namespace MissionPlanner.NoFly
             {
                 Utilities.nfz.HK.ConfirmNoFly += () =>
                 {
-                    return CustomMessageBox.Show("Show Hong Kong No fly zones?", "NoFly Zones", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes;
+                    return CustomMessageBox.Show("Показать зоны запрета полётов Гонконга?", "Зоны запрета полётов", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes;
                 };
 
                 var nfzinfo = Utilities.nfz.HK.LoadNFZ().Result;
@@ -128,7 +128,7 @@ namespace MissionPlanner.NoFly
             {
                 Utilities.nfz.EU.ConfirmNoFly += () =>
                 {
-                    return CustomMessageBox.Show("Show European Union No fly zones?", "NoFly Zones", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes;
+                    return CustomMessageBox.Show("Показать зоны запрета полётов Евросоюза?", "Зоны запрета полётов", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes;
                 };
 
                 var nfzinfo = Utilities.nfz.EU.LoadNFZ().Result;

--- a/Plugins/OpenDroneID2/OpenDroneID_Map_Status.cs
+++ b/Plugins/OpenDroneID2/OpenDroneID_Map_Status.cs
@@ -48,7 +48,7 @@ namespace MissionPlanner.Controls
 
         private void OpenDroneID_Map_Status_DoubleClick(object sender, EventArgs e)
         {
-            if (CustomMessageBox.Show("Are you sure you want to declare Remote ID Emergency?", "RID Emergency?", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes)
+            if (CustomMessageBox.Show("Вы уверены, что хотите объявить аварийный режим Remote ID?", "Аварийный режим RID?", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.Yes)
             {
                 try
                 {

--- a/Plugins/OpenDroneID2/OpenDroneID_Plugin.cs
+++ b/Plugins/OpenDroneID2/OpenDroneID_Plugin.cs
@@ -73,7 +73,7 @@ namespace OpenDroneID_Plugin
             // setup default if doesnt exist
             if (tabs == null)
             {
-                CustomMessageBox.Show("Restart Mission Planner to enable Drone ID Tab. Disable Plugin if Not Required CTRL-P");
+                CustomMessageBox.Show("Перезапустите Mission Planner, чтобы включить вкладку Drone ID. Отключите плагин, если он не нужен (CTRL-P)");
                 Host.MainForm.FlightData.saveTabControlActions();
                 tabs = Settings.Instance["tabcontrolactions"];
                 Settings.Instance.Save();

--- a/Plugins/OpenDroneID2/OpenDroneID_UI.cs
+++ b/Plugins/OpenDroneID2/OpenDroneID_UI.cs
@@ -352,7 +352,7 @@ namespace MissionPlanner.Controls
         {
             // Note: this function is for development only and should be removed for production enviroments. 
 
-            if (CustomMessageBox.Show("Are you sure you want to disable outgoing Remote ID?", "RID Developer Mode?", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.No)
+            if (CustomMessageBox.Show("Вы уверены, что хотите отключить передачу Remote ID?", "Режим разработчика RID?", CustomMessageBox.MessageBoxButtons.YesNo) == CustomMessageBox.DialogResult.No)
             {
                 return;
             }

--- a/Plugins/TerrainMakerPlugin/TerrainMakerPlugin.cs
+++ b/Plugins/TerrainMakerPlugin/TerrainMakerPlugin.cs
@@ -77,7 +77,7 @@ namespace TerrainMakerPlugin
             RectLatLng area = Host.FPGMapControl.SelectedArea;
             if (area.IsEmpty)
             {
-                var res = CustomMessageBox.Show("No area defined, use area displayed on screen?", "Terrain DAT",
+                var res = CustomMessageBox.Show("Область не выбрана. Использовать область на экране?", "Terrain DAT",
                     MessageBoxButtons.YesNo);
                 if (res == (int)DialogResult.Yes)
                 {
@@ -96,13 +96,13 @@ namespace TerrainMakerPlugin
                 int spacing = 30;
                 if (!int.TryParse(spacingstring, out spacing))
                 {
-                    CustomMessageBox.Show("Invalid Number", "ERROR");
+                    CustomMessageBox.Show("Неверное число", "ОШИБКА");
                     return;
                 }
 
                 if (spacing < 5 || spacing > 100)
                 {
-                    CustomMessageBox.Show("Spacing must be between 5 and 100 meters", "ERROR");
+                    CustomMessageBox.Show("Шаг должен быть от 5 до 100 метров", "ОШИБКА");
                     return;
                 }
 
@@ -144,7 +144,7 @@ namespace TerrainMakerPlugin
 
                         frmProgressReporter.Dispose();
 
-                        CustomMessageBox.Show("Terrain DAT created in Documents/Mission Planner/TerrainDat folder", "Terrain DAT");
+                        CustomMessageBox.Show("Файл Terrain DAT создан в папке Documents/Mission Planner/TerrainDat", "Terrain DAT");
 
 
                     }

--- a/Plugins/example22-payloadconfig.cs
+++ b/Plugins/example22-payloadconfig.cs
@@ -122,7 +122,7 @@ namespace MissionPlanner.plugins
             payloadCheckboxList.Enabled = !MainV2.comPort.MAV.cs.armed;
             if (MainV2.comPort.MAV.cs.armed)
             {
-                CustomMessageBox.Show("The vehicle is armed. Payload selection is disabled.", "Payload Selection");
+                CustomMessageBox.Show("Аппарат вооружён. Выбор полезной нагрузки отключён.", "Выбор полезной нагрузки");
             }
         }
 
@@ -213,7 +213,7 @@ namespace MissionPlanner.plugins
         {
             if (MainV2.comPort.MAV.param.TotalReceived != MainV2.comPort.MAV.param.TotalReported)
             {
-                CustomMessageBox.Show("The number of available parameters changed. A full param refresh will be done.", "Params");
+                CustomMessageBox.Show("Количество доступных параметров изменилось. Будет выполнено полное обновление списка.", "Параметры");
                 try
                 {
                     MainV2.comPort.getParamList();

--- a/Program.cs
+++ b/Program.cs
@@ -105,7 +105,7 @@ namespace MissionPlanner
                 config.SaveToDir("C:\\Temp\\Snapshot");
                 DotTrace.Attach(config);
                 DotTrace.StartCollectingData();
-                CustomMessageBox.Show("Trace started");
+                CustomMessageBox.Show("Трассировка запущена");
             }
             else
             {
@@ -764,7 +764,7 @@ namespace MissionPlanner
                 // i get alot of error from people who click the exe from inside a zip file.
             {
                 CustomMessageBox.Show(
-                    "You are missing some DLL's. Please extract the zip file somewhere. OR Use the update feature from the menu " +
+                    "Отсутствуют некоторые DLL. Распакуйте архив в отдельную папку или используйте функцию обновления в меню " +
                     ex.ToString());
                 // return;
             }
@@ -780,8 +780,8 @@ namespace MissionPlanner
             log.Info("Th Name " + Thread?.Name);
 
             var dr =
-                CustomMessageBox.Show("An error has occurred\n" + ex.ToString() + "\n\nReport this Error???",
-                    "Send Error", MessageBoxButtons.YesNo);
+                CustomMessageBox.Show("Произошла ошибка\n" + ex.ToString() + "\n\nОтправить отчёт об ошибке?",
+                    "Отправить отчёт", MessageBoxButtons.YesNo);
             if ((int) DialogResult.Yes == dr)
             {
                 try
@@ -854,7 +854,7 @@ namespace MissionPlanner
                 {
                     Console.WriteLine(exp.ToString());
                     log.Error(exp);
-                    CustomMessageBox.Show("Could not send report! Typically due to lack of internet connection.");
+                    CustomMessageBox.Show("Не удалось отправить отчёт. Вероятно отсутствует подключение к интернету.");
                 }
             }
         }

--- a/Radio/Sikradio.cs
+++ b/Radio/Sikradio.cs
@@ -419,7 +419,7 @@ S15: MAX_WINDOW=131
                     }
                     catch (Exception ex)
                     {
-                        MsgBox.CustomMessageBox.Show("Error copying file\n" + ex, "ERROR");
+                        MsgBox.CustomMessageBox.Show("Ошибка копирования файла\n" + ex, "ОШИБКА");
                         return false;
                     }
                     return true;
@@ -689,7 +689,7 @@ S15: MAX_WINDOW=131
             }
             else
             {
-                string ErrorMsg = Remote ? "Remote" : "Local" + " settings invalid, operation aborted:";
+                string ErrorMsg = (Remote ? "Удалённые" : "Локальные") + " настройки некорректны, операция прервана:";
 
                 foreach (var em in Errors)
                 {
@@ -749,7 +749,7 @@ S15: MAX_WINDOW=131
                         }
                         if (!cmdanswer.Contains("OK"))
                         {
-                            MsgBox.CustomMessageBox.Show("Set Command error");
+                            MsgBox.CustomMessageBox.Show("Ошибка выполнения команды");
                         }
 
                     }
@@ -763,7 +763,7 @@ S15: MAX_WINDOW=131
                         }
                         else
                         {
-                            MsgBox.CustomMessageBox.Show("Set Command error");
+                            MsgBox.CustomMessageBox.Show("Ошибка выполнения команды");
                         }
                     }
                 }
@@ -947,7 +947,7 @@ S15: MAX_WINDOW=131
                             {
                                 //Complain that encryption key invalid.
                                 lbl_status.Text = "Fail";
-                                MsgBox.CustomMessageBox.Show("Encryption key not valid hex number <= " + MaxKeyLength.ToString() + " hex numerals");
+                                MsgBox.CustomMessageBox.Show("Ключ шифрования не является допустимым шестнадцатеричным числом длиной не более " + MaxKeyLength.ToString() + " символов");
                             }
                         }
                         if (GetIsEncryptionEnabled(ENCRYPTION_LEVEL))
@@ -964,7 +964,7 @@ S15: MAX_WINDOW=131
                             {
                                 //Complain that encryption key invalid.
                                 lbl_status.Text = "Fail";
-                                MsgBox.CustomMessageBox.Show("Encryption key not valid hex number <= " + MaxKeyLength.ToString() + " hex numerals");
+                                MsgBox.CustomMessageBox.Show("Ключ шифрования не является допустимым шестнадцатеричным числом длиной не более " + MaxKeyLength.ToString() + " символов");
                             }
                         }
 
@@ -982,14 +982,14 @@ S15: MAX_WINDOW=131
                         var cmdwriteanswer = doCommand(Session.Port, "AT&W");
                         if (!cmdwriteanswer.Contains("OK"))
                         {
-                            MsgBox.CustomMessageBox.Show("Failed to save parameters");
+                            MsgBox.CustomMessageBox.Show("Не удалось сохранить параметры");
                         }
 
                         // return to normal mode
                         doCommand(Session.Port, "ATZ");
                     }
 
-                    lbl_status.Text = "Done";
+                    lbl_status.Text = "Готово";
                     EnableConfigControls(true, true);
                 }
                 else
@@ -998,7 +998,7 @@ S15: MAX_WINDOW=131
                     doCommand(Session.Port, "ATZ");
 
                     lbl_status.Text = "Fail";
-                    MsgBox.CustomMessageBox.Show("Failed to enter command mode");
+                    MsgBox.CustomMessageBox.Show("Не удалось перейти в режим команд");
                     EnableConfigControls(true, false);
                 }
 
@@ -1820,7 +1820,7 @@ S15: MAX_WINDOW=131
 
                         if ((RemoteFWVer != null) &&  (LocalFWVer != RemoteFWVer) && UsedAltRanges)
                         {
-                            MsgBox.CustomMessageBox.Show("The ranges and options shown for the remote modem may not be accurate.  To ensure accurate, use the same firmware version in both the local and remote modems");
+                            MsgBox.CustomMessageBox.Show("Диапазоны и параметры, отображаемые для удалённого модема, могут быть некорректны. Чтобы гарантировать корректность, используйте одинаковую версию прошивки на обоих модемах");
                         }
 
                         items = answer.Split('\n');
@@ -1864,11 +1864,11 @@ S15: MAX_WINDOW=131
 
                     if (SomeSettingsInvalid)
                     {
-                        lbl_status.Text = "Done.  Some settings in modem were invalid.";
+                        lbl_status.Text = "Готово. Некоторые параметры модема были некорректны.";
                     }
                     else
                     {
-                        lbl_status.Text = "Done";
+                        lbl_status.Text = "Готово";
                     }
                     EnableConfigControls(true, true);
 
@@ -1880,7 +1880,7 @@ S15: MAX_WINDOW=131
                     Session.PutIntoTransparentMode();
 
                     lbl_status.Text = "Fail";
-                    MsgBox.CustomMessageBox.Show("Failed to enter command mode.  Try power-cycling modem.");
+                    MsgBox.CustomMessageBox.Show("Не удалось перейти в режим команд. Попробуйте перезапустить модем.");
                     EnableConfigControls(true, false);
                 }
 
@@ -1895,7 +1895,7 @@ S15: MAX_WINDOW=131
             catch (Exception ex)
             {
                 lbl_status.Text = "Error";
-                MsgBox.CustomMessageBox.Show("Error during read " + ex);
+                MsgBox.CustomMessageBox.Show("Ошибка при чтении " + ex);
             }
             _AlreadyInEncCheckChangedEvtHdlr = false;
 
@@ -2089,12 +2089,12 @@ S15: MAX_WINDOW=131
 
         private void linkLabel1_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
-            MsgBox.CustomMessageBox.Show(@"The Sik Radios have 2 status LEDs, one red and one green.
-green LED blinking - searching for another radio 
-green LED solid - link is established with another radio 
-red LED flashing - transmitting data 
-red LED solid - in firmware update mode");
-        }
+            MsgBox.CustomMessageBox.Show(@"На модемах Sik есть два светодиода: красный и зелёный.
+зелёный мигает — поиск другого модема
+зелёный горит — установлен канал связи
+красный мигает — идёт передача данных
+красный горит — режим обновления прошивки");
+       }
 
         void DoCommandShowErrorIfNotOK(ICommsSerial Port, string cmd, string ErrorMsg)
         {
@@ -2142,11 +2142,11 @@ red LED solid - in firmware update mode");
 
                 Session.Port.DiscardInBuffer();
 
-                lbl_status.Text = "Doing Command ATI & AT&F";
+                lbl_status.Text = "Выполняется команда ATI & AT&F";
 
-                DoCommandShowErrorIfNotOK(Session.Port, "AT&F", "Failed to reset parameters to factory defaults");
+                DoCommandShowErrorIfNotOK(Session.Port, "AT&F", "Не удалось сбросить параметры к заводским");
 
-                DoCommandShowErrorIfNotOK(Session.Port, "AT&W", "Failed to write parameters to EEPROM");
+                DoCommandShowErrorIfNotOK(Session.Port, "AT&W", "Не удалось записать параметры в EEPROM");
 
                 lbl_status.Text = "Reset";
                 doCommand(Session.Port, "ATZ");
@@ -2160,7 +2160,7 @@ red LED solid - in firmware update mode");
                 Session.PutIntoTransparentMode();
 
                 lbl_status.Text = "Fail";
-                MsgBox.CustomMessageBox.Show("Failed to enter command mode.  Try power-cycling modem.");
+                MsgBox.CustomMessageBox.Show("Не удалось перейти в режим команд. Попробуйте перезапустить модем.");
             }
         }
 
@@ -2264,8 +2264,8 @@ red LED solid - in firmware update mode");
 
                 if (RFD900 == null)
                 {
-                    UpdateStatus("Unknown modem");
-                    MsgBox.CustomMessageBox.Show("Couldn't communicate with modem.  Try power-cycling modem.");
+                    UpdateStatus("Неизвестный модем");
+                    MsgBox.CustomMessageBox.Show("Не удалось связаться с модемом. Попробуйте перезапустить модем.");
                     EndSession();
                 }
                 else
@@ -2332,7 +2332,7 @@ red LED solid - in firmware update mode");
         private void Progressbar_Click(object sender, EventArgs e)
         {
             beta = !beta;
-            MsgBox.CustomMessageBox.Show("Beta set to " + beta);
+            MsgBox.CustomMessageBox.Show("Бета режим: " + beta);
         }
 
         private void linkLabel_mavlink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -2408,7 +2408,7 @@ red LED solid - in firmware update mode");
 
                 if (Result)
                 {
-                    lbl_status.Text = "Done";
+                    lbl_status.Text = "Готово";
                 }
                 else
                 {
@@ -2421,7 +2421,7 @@ red LED solid - in firmware update mode");
                 //doCommand(Session.Port, "ATO");
 
                 lbl_status.Text = "Fail";
-                MsgBox.CustomMessageBox.Show("Failed to enter command mode");
+                MsgBox.CustomMessageBox.Show("Не удалось перейти в режим команд");
             }
         }
 
@@ -2447,7 +2447,7 @@ red LED solid - in firmware update mode");
                 }
                 catch
                 {
-                    MsgBox.CustomMessageBox.Show("Invalid ComPort or in use");
+                    MsgBox.CustomMessageBox.Show("Неверный COM-порт или порт занят");
                     return null;
                 }
             }
@@ -2653,11 +2653,11 @@ red LED solid - in firmware update mode");
             {
                 if (ToSave.SaveToFile(dlgSave.FileName))
                 {
-                    System.Windows.Forms.MessageBox.Show("Saved settings to " + dlgSave.FileName + " OK");
+                    System.Windows.Forms.MessageBox.Show("Настройки сохранены в " + dlgSave.FileName + " OK");
                 }
                 else
                 {
-                    System.Windows.Forms.MessageBox.Show("Failed to save settings to " + dlgSave.FileName);
+                    System.Windows.Forms.MessageBox.Show("Не удалось сохранить настройки в " + dlgSave.FileName);
                 }
             }
         }
@@ -2683,7 +2683,7 @@ red LED solid - in firmware update mode");
 
                 if (x == null)
                 {
-                    System.Windows.Forms.MessageBox.Show("Failed to load settings from " + dlgOpen.FileName);
+                    System.Windows.Forms.MessageBox.Show("Не удалось загрузить настройки из " + dlgOpen.FileName);
                 }
                 else
                 {

--- a/ResEdit.cs
+++ b/ResEdit.cs
@@ -243,7 +243,7 @@ namespace resedit
                 {
                     try
                     {
-                        CustomMessageBox.Show("Failed to save " + row.Cells[colOtherLang.Index].Value.ToString() + " " +
+                        CustomMessageBox.Show("Не удалось сохранить " + row.Cells[colOtherLang.Index].Value.ToString() + " " +
                                               ex.ToString());
                     }
                     catch
@@ -263,7 +263,7 @@ namespace resedit
         {
             if (!File.Exists("translation/output.html"))
             {
-                CustomMessageBox.Show("No existing translation has been done");
+                CustomMessageBox.Show("Перевод ещё не выполнен");
                 return;
             }
 
@@ -297,7 +297,7 @@ namespace resedit
 
             sr1.Close();
 
-            CustomMessageBox.Show("Modified " + a + " entries");
+            CustomMessageBox.Show("Изменено записей: " + a);
         }
 
         private void comboBox1_SelectedIndexChanged(object sender, EventArgs e)
@@ -376,7 +376,7 @@ namespace resedit
                 }
             }
 
-            CustomMessageBox.Show("Loaded Existing");
+            CustomMessageBox.Show("Загружены существующие данные");
         }
 
 

--- a/SikRadio/RFD900.cs
+++ b/SikRadio/RFD900.cs
@@ -2314,7 +2314,7 @@ namespace RFD.RFD900
         {
             while (!TryFirmwareProgrammingOnce(FilePath, Progress))
             {
-                switch (System.Windows.Forms.MessageBox.Show("Programming firmware failed.  Try again?", "Programming firmware failed.  Try again?", System.Windows.Forms.MessageBoxButtons.YesNoCancel))
+                switch (System.Windows.Forms.MessageBox.Show("Не удалось прошить модем. Повторить попытку?", "Не удалось прошить модем. Повторить попытку?", System.Windows.Forms.MessageBoxButtons.YesNoCancel))
                 {
                     case System.Windows.Forms.DialogResult.Yes:
                         break;
@@ -2490,7 +2490,7 @@ namespace RFD.RFD900
                         }
                         else
                         {
-                            System.Windows.Forms.MessageBox.Show("The selected firmware is not certified to run on this modem.  Aborting.");
+                            System.Windows.Forms.MessageBox.Show("Выбранная прошивка не сертифицирована для этого модема. Прерывание.");
                             return false;
                         }
                     }

--- a/SikRadio/Rssi.cs
+++ b/SikRadio/Rssi.cs
@@ -63,17 +63,17 @@ namespace SikRadio
                         var ATIReply = Session.ATCClient.DoQuery("ATI", true);
                         if (RFDLib.Text.Contains(ATIReply, "async"))
                         {
-                            MissionPlanner.MsgBox.CustomMessageBox.Show("Firmware doesn't support RSSI reporting");
+                            MissionPlanner.MsgBox.CustomMessageBox.Show("Прошивка не поддерживает передачу RSSI");
                         }
                         else
                         {
-                            MissionPlanner.MsgBox.CustomMessageBox.Show("Failed to enter RSSI reporting mode.");
+                            MissionPlanner.MsgBox.CustomMessageBox.Show("Не удалось войти в режим отчёта RSSI.");
                         }
                     }
                 }
                 else
                 {
-                    MissionPlanner.MsgBox.CustomMessageBox.Show("Failed to put modem into AT command mode.");
+                    MissionPlanner.MsgBox.CustomMessageBox.Show("Не удалось перевести модем в режим AT-команд.");
                 }
             }
         }

--- a/SikRadio/Terminal.cs
+++ b/SikRadio/Terminal.cs
@@ -98,7 +98,7 @@ namespace SikRadio
                 }
                 else
                 {
-                    MissionPlanner.MsgBox.CustomMessageBox.Show("Failed to enter AT command mode.");
+                    MissionPlanner.MsgBox.CustomMessageBox.Show("Не удалось войти в режим AT-команд.");
                 }
             }
         }
@@ -291,7 +291,7 @@ namespace SikRadio
                     }
                     catch
                     {
-                        CustomMessageBox.Show("Error writing to com port", "Error");
+                        CustomMessageBox.Show("Ошибка записи в COM-порт", "Ошибка");
                     }
                 }
                 cmd = new StringBuilder();

--- a/Swarm/FollowPathControl.cs
+++ b/Swarm/FollowPathControl.cs
@@ -34,7 +34,7 @@ namespace MissionPlanner.Swarm
             CMB_mavs.ValueMember = "Value";
             CMB_mavs.DisplayMember = "Key";
 
-            MessageBox.Show("this is beta, use at own risk");
+            MessageBox.Show("Это бета-версия, используйте на свой страх и риск");
 
             MissionPlanner.Utilities.Tracking.AddPage(this.GetType().ToString(), this.Text);
         }
@@ -136,7 +136,7 @@ namespace MissionPlanner.Swarm
 
                 if (DateTime.Now > deadline)
                 {
-                    CustomMessageBox.Show("Timeout waiting for autoscan/no mavlink device connected");
+                    CustomMessageBox.Show("Тайм-аут ожидания автопоиска/подключения MAVLink устройства");
                     return;
                 }
             }

--- a/Swarm/FormationControl.cs
+++ b/Swarm/FormationControl.cs
@@ -46,7 +46,7 @@ namespace MissionPlanner.Swarm
 
             this.MouseWheel += new MouseEventHandler(FollowLeaderControl_MouseWheel);
 
-            MessageBox.Show("this is beta, use at own risk");
+            MessageBox.Show("Это бета-версия, используйте на свой страх и риск");
 
             MissionPlanner.Utilities.Tracking.AddPage(this.GetType().ToString(), this.Text);
         }
@@ -210,7 +210,7 @@ namespace MissionPlanner.Swarm
 
                 if (DateTime.Now > deadline)
                 {
-                    CustomMessageBox.Show("Timeout waiting for autoscan/no mavlink device connected");
+                    CustomMessageBox.Show("Истекло время ожидания автосканирования/нет подключения mavlink");
                     return;
                 }
             }
@@ -256,7 +256,7 @@ namespace MissionPlanner.Swarm
         {
             if (mav == SwarmInterface.Leader)
             {
-                CustomMessageBox.Show("Can not move Leader");
+                CustomMessageBox.Show("Невозможно переместить лидера");
                 ico.z = 0;
             }
             else

--- a/Swarm/WaypointLeader/WPControl.cs
+++ b/Swarm/WaypointLeader/WPControl.cs
@@ -87,7 +87,7 @@ namespace MissionPlanner.Swarm.WaypointLeader
                 {
                     if (MAV.cs.armed && MAV.cs.alt > 1)
                     {
-                        var result = CustomMessageBox.Show("There appears to be a drone in the air at the moment. Are you sure you want to continue?", "continue", MessageBoxButtons.YesNo);
+                        var result = CustomMessageBox.Show("Похоже, в данный момент беспилотник уже в воздухе. Продолжить?", "продолжить", MessageBoxButtons.YesNo);
                         if (result == (int)DialogResult.Yes)
                             break;
                         return;
@@ -299,7 +299,7 @@ namespace MissionPlanner.Swarm.WaypointLeader
                 {
                     if (MAV.cs.armed && MAV.cs.alt > 1)
                     {
-                        var result = CustomMessageBox.Show("There appears to be a drone in the air at the moment. Are you sure you want to continue?", "continue", MessageBoxButtons.YesNo);
+                        var result = CustomMessageBox.Show("Похоже, в данный момент беспилотник уже в воздухе. Продолжить?", "продолжить", MessageBoxButtons.YesNo);
                         if (result == (int)DialogResult.Yes)
                             break;
                         return;

--- a/plugins/Dowding/DowdingUI.cs
+++ b/plugins/Dowding/DowdingUI.cs
@@ -111,11 +111,11 @@ namespace Dowding
                 Settings.Instance["Dowding_server"] = cmb_server.Text;
                 Settings.Instance.Save();
 
-                CustomMessageBox.Show("Verified!");
+                CustomMessageBox.Show("Проверено!");
             }
             catch
             {
-                CustomMessageBox.Show("Username or password invalid");
+                CustomMessageBox.Show("Неверное имя пользователя или пароль");
             }
         }
 
@@ -230,7 +230,7 @@ namespace Dowding
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Error Connecting\nif using com0com please rename the ports to COM??");
+                    CustomMessageBox.Show("Ошибка подключения\nесли используется com0com, переименуйте порты в COM??");
                     return;
                 }
 
@@ -260,7 +260,7 @@ namespace Dowding
             catch
             {
                 ATthreadrun = false;
-                CustomMessageBox.Show("Failed to detect antenna tracker");
+                CustomMessageBox.Show("Не удалось обнаружить антенный трекер");
             }
 
             starttime = DateTime.Now;
@@ -381,7 +381,7 @@ namespace Dowding
                 }
                 catch (Exception ex)
                 {
-                    CustomMessageBox.Show("Failed to connect/send to tracker " + ex.Message, Strings.ERROR);
+                    CustomMessageBox.Show("Не удалось подключиться или отправить данные трекеру " + ex.Message, Strings.ERROR);
                     return;
                 }
                 finally
@@ -436,7 +436,7 @@ namespace Dowding
             }
             catch
             {
-                CustomMessageBox.Show("Failed to send home location", Strings.ERROR);
+                CustomMessageBox.Show("Не удалось отправить домашнюю точку", Strings.ERROR);
             }
         }
 
@@ -518,7 +518,7 @@ namespace Dowding
                 }
                 catch
                 {
-                    CustomMessageBox.Show("Error Connecting\nif using com0com please rename the ports to COM??");
+                    CustomMessageBox.Show("Ошибка подключения\nесли используется com0com, переименуйте порты в COM??");
                     return;
                 }
 

--- a/plugins/FaceMap/FaceMapPlugin.cs
+++ b/plugins/FaceMap/FaceMapPlugin.cs
@@ -65,7 +65,7 @@ namespace MissionPlanner
 
                 if ((GCSViews.FlightPlanner.altmode)Host.MainForm.FlightPlanner.CMB_altmode.SelectedValue == GCSViews.FlightPlanner.altmode.Terrain)
                 {
-                    CustomMessageBox.Show("Terrain following altitude mode cannot be used with the face mapping tool.", "Error");
+                    CustomMessageBox.Show("Режим высоты с учётом рельефа несовместим с инструментом Face Mapping.", "Ошибка");
                 }
                 else if (Host.FPDrawnPolygon != null && Host.FPDrawnPolygon.Points.Count > 2)
                 {
@@ -74,7 +74,7 @@ namespace MissionPlanner
                 else
                 {
                     if (
-                        CustomMessageBox.Show("No polygon defined. Load a file?", "Load File", MessageBoxButtons.YesNo) ==
+                        CustomMessageBox.Show("Полигон не определён. Загрузить файл?", "Загрузить файл", MessageBoxButtons.YesNo) ==
                         (int)DialogResult.Yes)
                     {
                         gridui.LoadFaceMap();

--- a/plugins/FaceMap/FaceMapUI.cs
+++ b/plugins/FaceMap/FaceMapUI.cs
@@ -1252,7 +1252,11 @@ namespace MissionPlanner
                 camera.sensorheight = float.Parse(TXT_sensheight.Text);
                 camera.sensorwidth = float.Parse(TXT_senswidth.Text);
             }
-            catch { CustomMessageBox.Show("One of your entries is not a valid number"); return; }
+            catch
+            {
+                CustomMessageBox.Show("Одно из введённых значений некорректно");
+                return;
+            }
 
             cameras[CMB_camera.Text] = camera;
 
@@ -1270,7 +1274,7 @@ namespace MissionPlanner
 
                 if (NUM_split.Value > 1 && CHK_toandland.Checked != true)
                 {
-                    CustomMessageBox.Show("You must use Land/RTL to split a mission", Strings.ERROR);
+                    CustomMessageBox.Show("Для разделения миссии необходимо использовать Land/RTL", Strings.ERROR);
                     return;
                 }
 

--- a/plugins/InitialParamsCalculator.cs
+++ b/plugins/InitialParamsCalculator.cs
@@ -117,12 +117,12 @@ namespace MissionPlanner.InitialParamCalc
 
 
             //Add intro and some warnings
-            CustomMessageBox.Show("This plugin will calculate some initial parameters based on battery and prop size for a new copter setup.\r\n\r\n" +
-                                  "Please make sure that before running this plugin and updating calculated parameters:\r\n" +
-                                  "ALL INITIAL SETUPS ARE DONE (Calibrations, frame settings, motor tests)\r\n" +
-                                  "BATTERY VOLTAGE MONITORING IS SET AND WORKING\r\n\r\n" +
-                                  "Note: INS_GYRO_FILTER with a value other than 20 is optional and probably only for small frames/props " +
-                                  "At first you can keep it at 20\r\n", "Initial Parameter Calculator");
+            CustomMessageBox.Show("Этот плагин вычислит начальные параметры для нового коптера исходя из батареи и размера пропеллера.\r\n\r\n" +
+                                  "Перед запуском плагина и обновлением параметров убедитесь, что:\r\n" +
+                                  "ВСЕ НАЧАЛЬНЫЕ НАСТРОЙКИ ВЫПОЛНЕНЫ (калибровки, тип рамы, тесты моторов)\r\n" +
+                                  "МОНИТОРИНГ НАПРЯЖЕНИЯ БАТАРЕИ НАСТРОЕН И РАБОТАЕТ\r\n\r\n" +
+                                  "Примечание: значение INS_GYRO_FILTER, отличное от 20, возможно, потребуется только для маленьких рам/пропов. " +
+                                  "Сначала можно оставить его равным 20\r\n", "Калькулятор начальных параметров");
 
             //Check environment
 
@@ -133,16 +133,16 @@ namespace MissionPlanner.InitialParamCalc
             }
             if (Host.cs.firmware != ArduPilot.Firmwares.ArduCopter2)
             {
-                CustomMessageBox.Show("Initial parameter calculation works with Arducopter only!", "Initial paremeter calculator", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                CustomMessageBox.Show("Расчёт начальных параметров работает только с ArduCopter!", "Калькулятор начальных параметров", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 
 
             // Get input parameters
-            if (MissionPlanner.Controls.InputBox.Show("Initial parameter calculator", "Enter airscrew size in inch", ref prop) != DialogResult.OK) return;
-            if (MissionPlanner.Controls.InputBox.Show("Initial parameter calculator", "Enter battery cellcount", ref cellcount) != DialogResult.OK) return;
-            if (MissionPlanner.Controls.InputBox.Show("Initial parameter calculator", "Enter battery cell fully charged voltage\r\nLiPo - 4.2, LipoHV - 4.35, LiIon - 4.1 or 4.2", ref cellmax) != DialogResult.OK) return;
-            if (MissionPlanner.Controls.InputBox.Show("Initial parameter calculator", "Enter battery cell fully discharged voltage\r\nLiPo/LipoHV - 3.3, LiIon - 2.8", ref cellmin) != DialogResult.OK) return;
+            if (MissionPlanner.Controls.InputBox.Show("Калькулятор начальных параметров", "Введите размер пропеллера в дюймах", ref prop) != DialogResult.OK) return;
+            if (MissionPlanner.Controls.InputBox.Show("Калькулятор начальных параметров", "Введите количество ячеек батареи", ref cellcount) != DialogResult.OK) return;
+            if (MissionPlanner.Controls.InputBox.Show("Калькулятор начальных параметров", "Введите напряжение полностью заряженной ячейки\r\nLiPo - 4.2, LipoHV - 4.35, LiIon - 4.1 или 4.2", ref cellmax) != DialogResult.OK) return;
+            if (MissionPlanner.Controls.InputBox.Show("Калькулятор начальных параметров", "Введите напряжение полностью разряженной ячейки\r\nLiPo/LipoHV - 3.3, LiIon - 2.8", ref cellmin) != DialogResult.OK) return;
 
 
 
@@ -157,7 +157,7 @@ namespace MissionPlanner.InitialParamCalc
 
             if (prop_size <= 0 || batt_cells < 1)
             {
-                CustomMessageBox.Show("Invalid input data!", "Initial paremeter calculator", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                CustomMessageBox.Show("Неверные исходные данные!", "Калькулятор начальных параметров", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
 

--- a/plugins/example2-menu.cs
+++ b/plugins/example2-menu.cs
@@ -64,10 +64,10 @@ namespace Shortcuts
 
         void but_Click(object sender, EventArgs e)
         {
-            CustomMessageBox.Show("This is a sample plugin\nSee the source in the plugins folder");
+            CustomMessageBox.Show("Это пример плагина\nСмотрите исходный код в папке plugins");
 
 			string angle = "0";
-            InputBox.Show("Enter Angle", "This will be the heading", ref angle);
+            InputBox.Show("Введите угол", "Это будет курс", ref angle);
 		    int angle_in_number = Int32.Parse(angle);
 			
 			Host.InsertWP(0, MAVLink.MAV_CMD.DO_SET_SERVO, 9, angle_in_number, 0, 0, 0, 0, 0);

--- a/temp.cs
+++ b/temp.cs
@@ -153,7 +153,7 @@ namespace MissionPlanner
 
             var removed = MainMap.Manager.PrimaryCache.DeleteOlderThan(DateTime.Now, Custom.Instance.DbId);
 
-            CustomMessageBox.Show("Removed " + removed + " images");
+            CustomMessageBox.Show("Удалено " + removed + " изображений");
 
             log.InfoFormat("Removed {0} images", removed);
 
@@ -661,7 +661,7 @@ namespace MissionPlanner
 
         private void but_reboot_Click(object sender, EventArgs e)
         {
-            if (CustomMessageBox.Show("Are you sure?", "", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
+            if (CustomMessageBox.Show("Вы уверены?", "", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
                 MainV2.comPort.doReboot(false, true);
         }
 
@@ -712,7 +712,7 @@ namespace MissionPlanner
             var removed = ((PureImageCache)MyImageCache.Instance).DeleteOlderThan(DateTime.Now.AddDays(-30),
                 FlightData.instance.gMapControl1.MapProvider.DbId);
 
-            CustomMessageBox.Show("Removed " + removed + " images");
+            CustomMessageBox.Show("Удалено " + removed + " изображений");
 
             log.InfoFormat("Removed {0} images", removed);
         }
@@ -977,11 +977,11 @@ namespace MissionPlanner
                             (byte) MainV2.comPort.compidcurrent, MAVLink.MAV_CMD.FLASH_BOOTLOADER, 0, 0, 0, 0, 290876,
                             0, 0))
                         {
-                            CustomMessageBox.Show("Upgraded bootloader");
+                            CustomMessageBox.Show("Загрузчик обновлён");
                         }
                         else
                         {
-                            CustomMessageBox.Show("Failed to upgrade bootloader");
+                            CustomMessageBox.Show("Не удалось обновить загрузчик");
                         }
                     }
                     catch (Exception ex)
@@ -998,7 +998,7 @@ namespace MissionPlanner
 
         private void but_anonlog_Click(object sender, EventArgs e)
         {
-            CustomMessageBox.Show("This is beta, please confirm the output file");
+            CustomMessageBox.Show("Это бета-версия, пожалуйста подтвердите имя выходного файла");
             using (OpenFileDialog ofd = new OpenFileDialog())
             {
                 ofd.Filter = "tlog or bin/log|*.tlog;*.bin;*.log";
@@ -1102,8 +1102,8 @@ namespace MissionPlanner
 
         private void but_disablearmswitch_Click(object sender, EventArgs e)
         {
-            if (CustomMessageBox.Show("Are you sure?", "", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
-            {   
+            if (CustomMessageBox.Show("Вы уверены?", "", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
+            {
                 var target_system = (byte)MainV2.comPort.sysidcurrent;
                 if (target_system == 0) {
                     log.Info("Not toggling safety on sysid 0");
@@ -1170,7 +1170,7 @@ namespace MissionPlanner
 
             var currentQNH = MainV2.comPort.GetParam(paramname).ToString();
             //338.6388 pa => 100' = 30.48m
-            CustomMessageBox.Show("use at your own risk!!!");
+            CustomMessageBox.Show("Используйте на свой страх и риск!!!");
 
             NumericUpDown mavlinkNumericUpDown = new NumericUpDown();
             mavlinkNumericUpDown.Minimum = -100;
@@ -1227,10 +1227,10 @@ namespace MissionPlanner
 
         private void but_lockup_Click(object sender, EventArgs e)
         {
-            if (CustomMessageBox.Show("Lockup the autopilot??? this can cause a CRASH!!!!!!",
-                    "Lockup", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
-                if (CustomMessageBox.Show("Lockup the autopilot??? this can cause a CRASH!!!!!!",
-                        "Lockup", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
+            if (CustomMessageBox.Show("Заблокировать автопилот? Это может привести к КРАШУ!",
+                    "Блокировка", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
+                if (CustomMessageBox.Show("Заблокировать автопилот? Это может привести к КРАШУ!",
+                        "Блокировка", MessageBoxButtons.YesNo, MessageBoxIcon.Warning) == (int)DialogResult.Yes)
                     MainV2.comPort.doCommand(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid,
                         MAVLink.MAV_CMD.PREFLIGHT_REBOOT_SHUTDOWN,
                         42, 24, 71, 93, 0, 0, 0, false);
@@ -1264,7 +1264,7 @@ namespace MissionPlanner
 
         private void but_paramrestore_Click(object sender, EventArgs e)
         {
-            CustomMessageBox.Show("This process make take a some time");
+            CustomMessageBox.Show("Этот процесс может занять некоторое время");
 
             using (var ofd = new OpenFileDialog
             {
@@ -1348,12 +1348,12 @@ namespace MissionPlanner
                         }
 
                         if (fails.Count > 0)
-                            CustomMessageBox.Show("Set " + set + " params \nAlready Set " 
-                                                  + alreadyset + " params \nFailed to set " 
+                            CustomMessageBox.Show("Установлено параметров: " + set + "\nУже было установлено: "
+                                                  + alreadyset + "\nНе удалось установить:" 
                                                   + fails.Aggregate((a, b) => a + "\n" + b));
                         else
-                            CustomMessageBox.Show("Set " + set + " params \nAlready Set "
-                                                  + alreadyset + " params");
+                            CustomMessageBox.Show("Установлено параметров: " + set + "\nУже было установлено: "
+                                                  + alreadyset);
 
                     };
 
@@ -1387,7 +1387,7 @@ namespace MissionPlanner
                 {
                     apj_tool.Process(ofd.FileName, ofd2.FileName);
 
-                    CustomMessageBox.Show("The new APJ has been saved with the source APJ");
+                    CustomMessageBox.Show("Новый файл APJ сохранён рядом с исходным");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- continue translating remaining user-facing prompts
- localize log download messages
- localize map tile prefetch messages
- add Russian strings for GMap export/import dialogs
- update resource file translations

## Testing
- `dotnet test MissionPlannerTests/MissionPlannerTests.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496ea3d2cc8329800a2b8419b9aabd